### PR TITLE
Returns an exit code (default 0 for success or exit code) based on command return

### DIFF
--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -54,9 +54,8 @@ module Hanami
         command, args = parse(result, out)
 
         result.before_callbacks.run(command, args)
-        command_ret = command.call(args)
+        command_ret = command.call(args) || 0
         result.after_callbacks.run(command, args)
-        command_ret = 0 if command_ret.nil?
         exit(command_ret)
       else
         usage(result, out)

--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -54,8 +54,10 @@ module Hanami
         command, args = parse(result, out)
 
         result.before_callbacks.run(command, args)
-        command.call(args)
+        command_ret = command.call(args)
         result.after_callbacks.run(command, args)
+        command_ret = 0 if command_ret.nil?
+        exit(command_ret)
       else
         usage(result, out)
       end

--- a/spec/integration/exit_code_spec.rb
+++ b/spec/integration/exit_code_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe "Commands" do
+  it "exit with standard 0 error code" do
+    `foo exit_code valid`
+
+    expect($?.exitstatus).to eq(0)
+  end
+
+  it "exit with 1 error code when fail" do
+    `foo exit_code invalid`
+
+    expect($?.exitstatus).to eq(1)
+  end
+end

--- a/spec/integration/exit_code_spec.rb
+++ b/spec/integration/exit_code_spec.rb
@@ -1,13 +1,15 @@
+require 'English'
+
 RSpec.describe "Commands" do
   it "exit with standard 0 error code" do
     `foo exit_code valid`
 
-    expect($?.exitstatus).to eq(0)
+    expect($CHILD_STATUS.exitstatus).to eq(0)
   end
 
   it "exit with 1 error code when fail" do
     `foo exit_code invalid`
 
-    expect($?.exitstatus).to eq(1)
+    expect($CHILD_STATUS.exitstatus).to eq(1)
   end
 end

--- a/spec/integration/rendering_spec.rb
+++ b/spec/integration/rendering_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "Rendering" do
         foo db [SUBCOMMAND]
         foo destroy [SUBCOMMAND]
         foo exec TASK [DIRS]                   # Execute a task
+        foo exit_code PERFORM                  # Return specific exit error code
         foo generate [SUBCOMMAND]
         foo greeting [RESPONSE]
         foo hello                              # Print a greeting
@@ -67,6 +68,7 @@ RSpec.describe "Rendering" do
         foo db [SUBCOMMAND]
         foo destroy [SUBCOMMAND]
         foo exec TASK [DIRS]                   # Execute a task
+        foo exit_code PERFORM                  # Return specific exit error code
         foo generate [SUBCOMMAND]
         foo greeting [RESPONSE]
         foo hello                              # Print a greeting
@@ -92,6 +94,7 @@ RSpec.describe "Rendering" do
         foo db [SUBCOMMAND]
         foo destroy [SUBCOMMAND]
         foo exec TASK [DIRS]                   # Execute a task
+        foo exit_code PERFORM                  # Return specific exit error code
         foo generate [SUBCOMMAND]
         foo greeting [RESPONSE]
         foo hello                              # Print a greeting

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -473,11 +473,9 @@ module Foo
 
         argument :perform, desc: "Perform what exit code?", type: :string, required: true
         def call(perform:, **)
-          if perform == "valid"
-            return 0
-          elsif perform == "invalid"
-            return 1
-          end
+          return 0 if perform == "valid"
+
+          1
         end
       end
 

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -468,6 +468,19 @@ module Foo
         end
       end
 
+      class ExitCode < Hanami::CLI::Command
+        desc "Return specific exit error code"
+
+        argument :perform, desc: "Perform what exit code?", type: :string, required: true
+        def call(perform:, **)
+          if perform == "valid"
+            return 0
+          elsif perform == "invalid"
+            return 1
+          end
+        end
+      end
+
       class Hello < Hanami::CLI::Command
         desc "Print a greeting"
 
@@ -499,6 +512,7 @@ end
 
 Foo::CLI::Commands.register "generate webpack", Foo::Webpack::CLI::Generate
 Foo::CLI::Commands.register "hello",            Foo::Webpack::CLI::Hello
+Foo::CLI::Commands.register "exit_code",        Foo::Webpack::CLI::ExitCode
 Foo::CLI::Commands.register "sub command",      Foo::Webpack::CLI::SubCommand
 Foo::CLI::Commands.register "callbacks",        Foo::Webpack::CLI::CallbacksCommand
 


### PR DESCRIPTION
This PR is just a kickstart to discuss https://github.com/hanami/cli/issues/47 (motivation is on https://github.com/hanami/cli/issues/47#issuecomment-444873040)

I'm pretty sure just the return of command is not a good solution, AND it should be more reliable/explicit... maybe set the return with a specific method on the `Command` and not rely only on the return of the `call` method

Anyway, I'm just opening this PR so we can discuss if it worths to implement, and the best design for the problem.

ps: I isolated the test on a separated file so would be easy to check and discuss it, I tried to touch the current implementation as few as possible

thank you!