### PR TITLE
Moving hanami/cli under dry-rb namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Hanami::CLI
+# Dry::CLI
 General purpose Command Line Interface (CLI) framework for Ruby
 
 ## v0.3.1 - 2019-01-18

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hanami::CLI
+# Dry::CLI (former Hanami::CLI)
 
 General purpose Command Line Interface (CLI) framework for Ruby.
 
@@ -7,9 +7,9 @@ General purpose Command Line Interface (CLI) framework for Ruby.
 ## Status
 
 [![Gem Version](https://badge.fury.io/rb/hanami-cli.svg)](https://badge.fury.io/rb/hanami-cli)
-[![TravisCI](https://travis-ci.org/hanami/cli.svg?branch=master)](https://travis-ci.org/hanami/cli)
+[![TravisCI](https://travis-ci.org/dry-rb/dry-cli.svg?branch=master)](https://travis-ci.org/dry-rb/dry-cli)
 [![CircleCI](https://circleci.com/gh/hanami/cli/tree/master.svg?style=svg)](https://circleci.com/gh/hanami/cli/tree/master)
-[![Test Coverage](https://codecov.io/gh/hanami/cli/branch/master/graph/badge.svg)](https://codecov.io/gh/hanami/cli)
+[![Test Coverage](https://codecov.io/gh/dry-rb/dry-cli/branch/master/graph/badge.svg)](https://codecov.io/gh/dry-rb/dry-cli)
 [![Depfu](https://badges.depfu.com/badges/2c1bc076f16c6b5508334c44b5800362/overview.svg)](https://depfu.com/github/hanami/cli?project=Bundler)
 [![Inline Docs](http://inch-ci.org/github/hanami/cli.svg)](http://inch-ci.org/github/hanami/cli)
 
@@ -17,21 +17,21 @@ General purpose Command Line Interface (CLI) framework for Ruby.
 
 * Home page: http://hanamirb.org
 * Mailing List: http://hanamirb.org/mailing-list
-* API Doc: http://rdoc.info/gems/hanami-cli
-* Bugs/Issues: https://github.com/hanami/cli/issues
-* Support: http://stackoverflow.com/questions/tagged/hanami
+* API Doc: http://rdoc.info/gems/dry-cli
+* Bugs/Issues: https://github.com/dry-rb/dry-cli/issues
+* Support: http://stackoverflow.com/questions/tagged/dry-cli
 * Chat: http://chat.hanamirb.org
 
 ## Rubies
 
-__Hanami::CLI__ supports Ruby (MRI) 2.3+, JRuby 9.1.5.0+
+__Dry::CLI__ supports Ruby (MRI) 2.3+, JRuby 9.1.5.0+
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'hanami-cli'
+gem 'dry-cli'
 ```
 
 And then execute:
@@ -40,7 +40,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install hanami-cli
+    $ gem install dry-cli
 
 <!-- Tocer[start]: Auto-generated, don't remove. -->
 
@@ -84,14 +84,14 @@ Example: for `foo hi` _command name_ there is the corresponding `Foo::CLI::Hello
 ```ruby
 #!/usr/bin/env ruby
 require "bundler/setup"
-require "hanami/cli"
+require "dry/cli"
 
 module Foo
   module CLI
     module Commands
-      extend Hanami::CLI::Registry
+      extend Dry::CLI::Registry
 
-      class Hello < Hanami::CLI::Command
+      class Hello < Dry::CLI::Command
         def call(*)
         end
       end
@@ -99,7 +99,7 @@ module Foo
   end
 end
 
-class Version < Hanami::CLI::Command
+class Version < Dry::CLI::Command
   def call(*)
   end
 end
@@ -107,7 +107,7 @@ end
 Foo::CLI::Commands.register "hi", Foo::CLI::Commands::Hello
 Foo::CLI::Commands.register "v",  Version
 
-Hanami::CLI.new(Foo::CLI::Commands).call
+Dry::CLI.new(Foo::CLI::Commands).call
 ```
 
 **Please note:** there is NOT a convention between the _command name_ and the _command object_ class.
@@ -115,7 +115,7 @@ The manual _registration_ assigns a _command object_ to a _command name_.
 
 ### Commands as objects
 
-A command is a subclass of `Hanami::CLI::Command` and it MUST respond to `#call(*)`.
+A command is a subclass of `Dry::CLI::Command` and it MUST respond to `#call(*)`.
 
 ### Subcommands
 
@@ -124,15 +124,15 @@ There is nothing special in subcommands: they are just _command objects_ registe
 ```ruby
 #!/usr/bin/env ruby
 require "bundler/setup"
-require "hanami/cli"
+require "dry/cli"
 
 module Foo
   module CLI
     module Commands
-      extend Hanami::CLI::Registry
+      extend Dry::CLI::Registry
 
       module Generate
-        class Configuration < Hanami::CLI::Command
+        class Configuration < Dry::CLI::Command
           def call(*)
           end
         end
@@ -143,7 +143,7 @@ end
 
 Foo::CLI::Commands.register "generate configuration", Foo::CLI::Commands::Generate::Configuration
 
-Hanami::CLI.new(Foo::CLI::Commands).call
+Dry::CLI.new(Foo::CLI::Commands).call
 ```
 
 ### Arguments
@@ -156,14 +156,14 @@ An argument can be declared as _required_.
 ```ruby
 #!/usr/bin/env ruby
 require "bundler/setup"
-require "hanami/cli"
+require "dry/cli"
 
 module Foo
   module CLI
     module Commands
-      extend Hanami::CLI::Registry
+      extend Dry::CLI::Registry
 
-      class Greet < Hanami::CLI::Command
+      class Greet < Dry::CLI::Command
         argument :name, required: true, desc: "The name of the person to greet"
         argument :age, desc: "The age of the person to greet"
 
@@ -180,7 +180,7 @@ module Foo
   end
 end
 
-Hanami::CLI.new(Foo::CLI::Commands).call
+Dry::CLI.new(Foo::CLI::Commands).call
 ```
 
 ```shell
@@ -209,14 +209,14 @@ A command can accept none or many options.
 ```ruby
 #!/usr/bin/env ruby
 require "bundler/setup"
-require "hanami/cli"
+require "dry/cli"
 
 module Foo
   module CLI
     module Commands
-      extend Hanami::CLI::Registry
+      extend Dry::CLI::Registry
 
-      class Request < Hanami::CLI::Command
+      class Request < Dry::CLI::Command
         option :mode, default: "http", values: %w[http http2], desc: "The request mode"
 
         def call(**options)
@@ -229,7 +229,7 @@ module Foo
   end
 end
 
-Hanami::CLI.new(Foo::CLI::Commands).call
+Dry::CLI.new(Foo::CLI::Commands).call
 ```
 
 ```shell
@@ -257,14 +257,14 @@ These extra arguments are included as `:args` in the keyword arguments available
 ```ruby
 #!/usr/bin/env ruby
 require "bundler/setup"
-require "hanami/cli"
+require "dry/cli"
 
 module Foo
   module CLI
     module Commands
-      extend Hanami::CLI::Registry
+      extend Dry::CLI::Registry
 
-      class Runner < Hanami::CLI::Command
+      class Runner < Dry::CLI::Command
         argument :image, required: true, desc: "Docker image"
 
         def call(image:, args: [], **)
@@ -277,7 +277,7 @@ module Foo
   end
 end
 
-Hanami::CLI.new(Foo::CLI::Commands).call
+Dry::CLI.new(Foo::CLI::Commands).call
 ```
 
 ```shell
@@ -293,7 +293,7 @@ In this specific case, `ruby:latest` corresponds to the `image` mandatory argume
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "hanami-cli"
+gem "dry-cli"
 ```
 
 And then execute:
@@ -302,7 +302,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install hanami-cli
+    $ gem install dry-cli
 
 ## Usage
 
@@ -311,14 +311,14 @@ Imagine to build a CLI executable `foo` for your Ruby project.
 ```ruby
 #!/usr/bin/env ruby
 require "bundler/setup"
-require "hanami/cli"
+require "dry/cli"
 
 module Foo
   module CLI
     module Commands
-      extend Hanami::CLI::Registry
+      extend Dry::CLI::Registry
 
-      class Version < Hanami::CLI::Command
+      class Version < Dry::CLI::Command
         desc "Print version"
 
         def call(*)
@@ -326,7 +326,7 @@ module Foo
         end
       end
 
-      class Echo < Hanami::CLI::Command
+      class Echo < Dry::CLI::Command
         desc "Print input"
 
         argument :input, desc: "Input to print"
@@ -345,7 +345,7 @@ module Foo
         end
       end
 
-      class Start < Hanami::CLI::Command
+      class Start < Dry::CLI::Command
         desc "Start Foo machinery"
 
         argument :root, required: true, desc: "Root directory"
@@ -359,7 +359,7 @@ module Foo
         end
       end
 
-      class Stop < Hanami::CLI::Command
+      class Stop < Dry::CLI::Command
         desc "Stop Foo machinery"
 
         option :graceful, type: :boolean, default: true, desc: "Graceful stop"
@@ -369,7 +369,7 @@ module Foo
         end
       end
 
-      class Exec < Hanami::CLI::Command
+      class Exec < Dry::CLI::Command
         desc "Execute a task"
 
         argument :task, type: :string, required: true,  desc: "Task to be executed"
@@ -381,7 +381,7 @@ module Foo
       end
 
       module Generate
-        class Configuration < Hanami::CLI::Command
+        class Configuration < Dry::CLI::Command
           desc "Generate configuration"
 
           option :apps, type: :array, default: [], desc: "Generate configuration for specific apps"
@@ -391,7 +391,7 @@ module Foo
           end
         end
 
-        class Test < Hanami::CLI::Command
+        class Test < Dry::CLI::Command
           desc "Generate tests"
 
           option :framework, default: "minitest", values: %w[minitest rspec]
@@ -416,7 +416,7 @@ module Foo
   end
 end
 
-Hanami::CLI.new(Foo::CLI::Commands).call
+Dry::CLI.new(Foo::CLI::Commands).call
 ```
 
 Let's have a look at the command line usage.
@@ -578,14 +578,14 @@ From the `foo` gem we have a command `hello`.
 
 ```ruby
 #!/usr/bin/env ruby
-require "hanami/cli"
+require "dry/cli"
 
 module Foo
   module CLI
     module Commands
-      extend Hanami::CLI::Registry
+      extend Dry::CLI::Registry
 
-      class Hello < Hanami::CLI::Command
+      class Hello < Dry::CLI::Command
         argument :name, required: true
 
         def call(name:, **)
@@ -598,7 +598,7 @@ end
 
 Foo::CLI::Commands.register "hello", Foo::CLI::Commands::Hello
 
-cli = Hanami::CLI.new(Foo::CLI::Commands)
+cli = Dry::CLI.new(Foo::CLI::Commands)
 cli.call
 ```
 
@@ -624,7 +624,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/hanami/cli.
+Bug reports and pull requests are welcome on GitHub at https://github.com/dry-rb/dry-cli.
 
 ## Alternatives
 

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "hanami/cli"
+require "dry/cli"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/dry-cli.gemspec
+++ b/dry-cli.gemspec
@@ -1,20 +1,20 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'hanami/cli/version'
+require 'dry/cli/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "hanami-cli"
-  spec.version       = Hanami::CLI::VERSION
+  spec.name          = "dry-cli"
+  spec.version       = Dry::CLI::VERSION
   spec.authors       = ["Luca Guidi"]
   spec.email         = ["me@lucaguidi.com"]
   spec.licenses      = ["MIT"]
 
-  spec.summary       = "Hanami CLI"
-  spec.description   = "Hanami framework to build command line interfaces with Ruby"
+  spec.summary       = "Dry CLI"
+  spec.description   = "Common framework to build command line interfaces with Ruby"
   spec.homepage      = "http://hanamirb.org"
 
   spec.metadata['allowed_push_host'] = "https://rubygems.org"
-  spec.metadata['source_code_uri'] = "https://github.com/hanami/cli"
+  spec.metadata['source_code_uri'] = "https://github.com/dry-rb/dry-cli"
 
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/lib/dry/cli.rb
+++ b/lib/dry/cli.rb
@@ -1,24 +1,24 @@
-# Hanami
+# Dry
 #
 # @since 0.1.0
-module Hanami
+module Dry
   # General purpose Command Line Interface (CLI) framework for Ruby
   #
   # @since 0.1.0
   class CLI
-    require "hanami/cli/version"
-    require "hanami/cli/errors"
-    require "hanami/cli/command"
-    require "hanami/cli/registry"
-    require "hanami/cli/parser"
-    require "hanami/cli/usage"
-    require "hanami/cli/banner"
+    require "dry/cli/version"
+    require "dry/cli/errors"
+    require "dry/cli/command"
+    require "dry/cli/registry"
+    require "dry/cli/parser"
+    require "dry/cli/usage"
+    require "dry/cli/banner"
 
     # Check if command
     #
     # @param command [Object] the command to check
     #
-    # @return [TrueClass,FalseClass] true if instance of `Hanami::CLI::Command`
+    # @return [TrueClass,FalseClass] true if instance of `Dry::CLI::Command`
     #
     # @since 0.1.0
     # @api private
@@ -33,9 +33,9 @@ module Hanami
 
     # Create a new instance
     #
-    # @param registry [Hanami::CLI::Registry] a registry
+    # @param registry [Dry::CLI::Registry] a registry
     #
-    # @return [Hanami::CLI] the new instance
+    # @return [Dry::CLI] the new instance
     # @since 0.1.0
     def initialize(registry)
       @commands = registry
@@ -71,7 +71,7 @@ module Hanami
     #
     # It may exit in case of error, or in case of help.
     #
-    # @param result [Hanami::CLI::CommandRegistry::LookupResult]
+    # @param result [Dry::CLI::CommandRegistry::LookupResult]
     # @param out [IO] sta output
     #
     # @return [Array<Hanami:CLI::Command, Array>] returns an array where the
@@ -100,7 +100,7 @@ module Hanami
 
     # Prints the command usage and exit.
     #
-    # @param result [Hanami::CLI::CommandRegistry::LookupResult]
+    # @param result [Dry::CLI::CommandRegistry::LookupResult]
     # @param out [IO] sta output
     #
     # @since 0.1.0
@@ -114,7 +114,7 @@ module Hanami
     #
     # @param command [Object] the command to check
     #
-    # @return [TrueClass,FalseClass] true if instance of `Hanami::CLI::Command`
+    # @return [TrueClass,FalseClass] true if instance of `Dry::CLI::Command`
     #
     # @since 0.1.0
     # @api private

--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -1,6 +1,6 @@
-require "hanami/cli/program_name"
+require "dry/cli/program_name"
 
-module Hanami
+module Dry
   class CLI
     # Command banner
     #
@@ -9,7 +9,7 @@ module Hanami
     module Banner
       # Prints command banner
       #
-      # @param command [Hanami::CLI::Command] the command
+      # @param command [Dry::CLI::Command] the command
       # @param out [IO] standard output
       #
       # @since 0.1.0
@@ -103,7 +103,7 @@ module Hanami
       # rubocop:disable Metrics/MethodLength
       def self.extended_command_options(command)
         result = command.options.map do |option|
-          name = Utils::String.dasherize(option.name)
+          name = Hanami::Utils::String.dasherize(option.name)
           name = if option.boolean?
                    "[no-]#{name}"
                  else

--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -1,8 +1,8 @@
 require "forwardable"
 require "concurrent/array"
-require "hanami/cli/option"
+require "dry/cli/option"
 
-module Hanami
+module Dry
   class CLI
     # Base class for commands
     #
@@ -55,9 +55,9 @@ module Hanami
       # @since 0.1.0
       #
       # @example
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
-      #   class Echo < Hanami::CLI::Command
+      #   class Echo < Dry::CLI::Command
       #     desc "Prints given input"
       #
       #     def call(*)
@@ -75,9 +75,9 @@ module Hanami
       # @since 0.1.0
       #
       # @example
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
-      #   class Server < Hanami::CLI::Command
+      #   class Server < Dry::CLI::Command
       #     example [
       #       "                    # Basic usage (it uses the bundled server engine)",
       #       "--server=webrick    # Force `webrick` server engine",
@@ -112,9 +112,9 @@ module Hanami
       # @since 0.1.0
       #
       # @example Optional argument
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
-      #   class Hello < Hanami::CLI::Command
+      #   class Hello < Dry::CLI::Command
       #     argument :name
       #
       #     def call(name: nil, **)
@@ -133,9 +133,9 @@ module Hanami
       #   #   Hello, Luca
       #
       # @example Required argument
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
-      #   class Hello < Hanami::CLI::Command
+      #   class Hello < Dry::CLI::Command
       #     argument :name, required: true
       #
       #     def call(name:, **)
@@ -151,10 +151,10 @@ module Hanami
       #   #   Usage: "foo hello NAME"
       #
       # @example Multiple arguments
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
       #   module Generate
-      #     class Action < Hanami::CLI::Command
+      #     class Action < Dry::CLI::Command
       #       argument :app,    required: true
       #       argument :action, required: true
       #
@@ -172,9 +172,9 @@ module Hanami
       #   #   Usage: "foo generate action APP ACTION"
       #
       # @example Description
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
-      #   class Hello < Hanami::CLI::Command
+      #   class Hello < Dry::CLI::Command
       #     argument :name, desc: "The name of the person to greet"
       #
       #     def call(name: nil, **)
@@ -206,9 +206,9 @@ module Hanami
       # @since 0.1.0
       #
       # @example Basic usage
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
-      #   class Console < Hanami::CLI::Command
+      #   class Console < Dry::CLI::Command
       #     param :engine
       #
       #     def call(engine: nil, **)
@@ -223,9 +223,9 @@ module Hanami
       #   # starting console (engine: pry)
       #
       # @example List values
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
-      #   class Console < Hanami::CLI::Command
+      #   class Console < Dry::CLI::Command
       #     param :engine, values: %w(irb pry ripl)
       #
       #     def call(engine: nil, **)
@@ -243,9 +243,9 @@ module Hanami
       #   # Error: Invalid param provided
       #
       # @example Description
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
-      #   class Console < Hanami::CLI::Command
+      #   class Console < Dry::CLI::Command
       #     param :engine, desc: "Force a console engine"
       #
       #     def call(engine: nil, **)
@@ -261,9 +261,9 @@ module Hanami
       #   #   --help, -h                      # Print this help
       #
       # @example Boolean
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
-      #   class Server < Hanami::CLI::Command
+      #   class Server < Dry::CLI::Command
       #     param :code_reloading, type: :boolean, default: true
       #
       #     def call(code_reloading:, **)
@@ -284,9 +284,9 @@ module Hanami
       #   #   --[no]-code-reloading
       #
       # @example Aliases
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
-      #   class Server < Hanami::CLI::Command
+      #   class Server < Dry::CLI::Command
       #     param :port, aliases: ["-p"]
       #
       #     def call(options)

--- a/lib/dry/cli/command_registry.rb
+++ b/lib/dry/cli/command_registry.rb
@@ -1,7 +1,7 @@
 require "concurrent/hash"
 require 'hanami/utils/callbacks'
 
-module Hanami
+module Dry
   class CLI
     # Command registry
     #
@@ -113,8 +113,8 @@ module Hanami
           @aliases  = Concurrent::Hash.new
           @command  = nil
 
-          @before_callbacks = Utils::Callbacks::Chain.new
-          @after_callbacks = Utils::Callbacks::Chain.new
+          @before_callbacks = Hanami::Utils::Callbacks::Chain.new
+          @after_callbacks = Hanami::Utils::Callbacks::Chain.new
         end
 
         # @since 0.1.0

--- a/lib/dry/cli/errors.rb
+++ b/lib/dry/cli/errors.rb
@@ -1,6 +1,6 @@
 require "hanami/utils/deprecation"
 
-module Hanami
+module Dry
   # General purpose Command Line Interface (CLI) framework for Ruby
   #
   # @since 0.1.0

--- a/lib/dry/cli/option.rb
+++ b/lib/dry/cli/option.rb
@@ -1,6 +1,6 @@
 require "hanami/utils/string"
 
-module Hanami
+module Dry
   class CLI
     # Command line option
     #

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -1,7 +1,7 @@
 require "optparse"
-require "hanami/cli/program_name"
+require "dry/cli/program_name"
 
-module Hanami
+module Dry
   class CLI
     # Parse command line arguments and options
     #

--- a/lib/dry/cli/program_name.rb
+++ b/lib/dry/cli/program_name.rb
@@ -1,4 +1,4 @@
-module Hanami
+module Dry
   class CLI
     # Program name
     #

--- a/lib/dry/cli/registry.rb
+++ b/lib/dry/cli/registry.rb
@@ -1,6 +1,6 @@
-require "hanami/cli/command_registry"
+require "dry/cli/command_registry"
 
-module Hanami
+module Dry
   class CLI
     # Registry mixin
     #
@@ -17,20 +17,20 @@ module Hanami
       # Register a command
       #
       # @param name [String] the command name
-      # @param command [NilClass,Hanami::CLI::Command] the optional command
+      # @param command [NilClass,Dry::CLI::Command] the optional command
       # @param aliases [Array<String>] an optional list of aliases
       # @param options [Hash] a set of options
       #
       # @since 0.1.0
       #
       # @example Register a command
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
       #   module Foo
       #     module Commands
-      #       extend Hanami::CLI::Registry
+      #       extend Dry::CLI::Registry
       #
-      #       class Hello < Hanami::CLI::Command
+      #       class Hello < Dry::CLI::Command
       #       end
       #
       #       register "hi", Hello
@@ -38,13 +38,13 @@ module Hanami
       #   end
       #
       # @example Register a command with aliases
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
       #   module Foo
       #     module Commands
-      #       extend Hanami::CLI::Registry
+      #       extend Dry::CLI::Registry
       #
-      #       class Hello < Hanami::CLI::Command
+      #       class Hello < Dry::CLI::Command
       #       end
       #
       #       register "hello", Hello, aliases: ["hi", "ciao"]
@@ -52,17 +52,17 @@ module Hanami
       #   end
       #
       # @example Register a group of commands
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
       #   module Foo
       #     module Commands
-      #       extend Hanami::CLI::Registry
+      #       extend Dry::CLI::Registry
       #
       #       module Generate
-      #         class App < Hanami::CLI::Command
+      #         class App < Dry::CLI::Command
       #         end
       #
-      #         class Action < Hanami::CLI::Command
+      #         class Action < Dry::CLI::Command
       #         end
       #       end
       #
@@ -87,20 +87,20 @@ module Hanami
       #   it MUST respond to `#call`.
       # @param blk [Proc] the callback espressed as a block
       #
-      # @raise [Hanami::CLI::UnknownCommandError] if the command isn't registered
-      # @raise [Hanami::CLI::InvalidCallbackError] if the given callback doesn't
+      # @raise [Dry::CLI::UnknownCommandError] if the command isn't registered
+      # @raise [Dry::CLI::InvalidCallbackError] if the given callback doesn't
       #   implement the required interface
       #
       # @since 0.2.0
       #
       # @example
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
       #   module Foo
       #     module Commands
-      #       extend Hanami::CLI::Registry
+      #       extend Dry::CLI::Registry
       #
-      #       class Hello < Hanami::CLI::Command
+      #       class Hello < Dry::CLI::Command
       #         def call(*)
       #           puts "hello"
       #         end
@@ -112,7 +112,7 @@ module Hanami
       #   end
       #
       # @example Register an object as callback
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
       #   module Callbacks
       #     class Hello
@@ -124,9 +124,9 @@ module Hanami
       #
       #   module Foo
       #     module Commands
-      #       extend Hanami::CLI::Registry
+      #       extend Dry::CLI::Registry
       #
-      #       class Hello < Hanami::CLI::Command
+      #       class Hello < Dry::CLI::Command
       #         def call(*)
       #           puts "I'm about to say.."
       #         end
@@ -138,7 +138,7 @@ module Hanami
       #   end
       #
       # @example Register a class as callback
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
       #   module Callbacks
       #     class Hello
@@ -150,9 +150,9 @@ module Hanami
       #
       #   module Foo
       #     module Commands
-      #       extend Hanami::CLI::Registry
+      #       extend Dry::CLI::Registry
       #
-      #       class Hello < Hanami::CLI::Command
+      #       class Hello < Dry::CLI::Command
       #         def call(*)
       #           puts "I'm about to say.."
       #         end
@@ -173,20 +173,20 @@ module Hanami
       #   it MUST respond to `#call`.
       # @param blk [Proc] the callback espressed as a block
       #
-      # @raise [Hanami::CLI::UnknownCommandError] if the command isn't registered
-      # @raise [Hanami::CLI::InvalidCallbackError] if the given callback doesn't
+      # @raise [Dry::CLI::UnknownCommandError] if the command isn't registered
+      # @raise [Dry::CLI::InvalidCallbackError] if the given callback doesn't
       #   implement the required interface
       #
       # @since 0.2.0
       #
       # @example
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
       #   module Foo
       #     module Commands
-      #       extend Hanami::CLI::Registry
+      #       extend Dry::CLI::Registry
       #
-      #       class Hello < Hanami::CLI::Command
+      #       class Hello < Dry::CLI::Command
       #         def call(*)
       #           puts "hello"
       #         end
@@ -198,7 +198,7 @@ module Hanami
       #   end
       #
       # @example Register an object as callback
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
       #   module Callbacks
       #     class World
@@ -210,9 +210,9 @@ module Hanami
       #
       #   module Foo
       #     module Commands
-      #       extend Hanami::CLI::Registry
+      #       extend Dry::CLI::Registry
       #
-      #       class Hello < Hanami::CLI::Command
+      #       class Hello < Dry::CLI::Command
       #         def call(*)
       #           puts "hello"
       #         end
@@ -224,7 +224,7 @@ module Hanami
       #   end
       #
       # @example Register a class as callback
-      #   require "hanami/cli"
+      #   require "dry/cli"
       #
       #   module Callbacks
       #     class World
@@ -236,9 +236,9 @@ module Hanami
       #
       #   module Foo
       #     module Commands
-      #       extend Hanami::CLI::Registry
+      #       extend Dry::CLI::Registry
       #
-      #       class Hello < Hanami::CLI::Command
+      #       class Hello < Dry::CLI::Command
       #         def call(*)
       #           puts "hello"
       #         end
@@ -307,7 +307,7 @@ module Hanami
 
         # @since 0.1.0
         #
-        # @see Hanami::CLI::Registry#register
+        # @see Dry::CLI::Registry#register
         def register(name, command, aliases: [], **options)
           command_name = "#{prefix} #{name}"
           registry.set(command_name, command, aliases, **options)

--- a/lib/dry/cli/usage.rb
+++ b/lib/dry/cli/usage.rb
@@ -1,6 +1,6 @@
-require "hanami/cli/program_name"
+require "dry/cli/program_name"
 
-module Hanami
+module Dry
   class CLI
     # Command(s) usage
     #

--- a/lib/dry/cli/version.rb
+++ b/lib/dry/cli/version.rb
@@ -1,4 +1,4 @@
-module Hanami
+module Dry
   class CLI
     # @since 0.1.0
     VERSION = "0.3.1".freeze

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 $LOAD_PATH.unshift "lib"
 require "hanami/utils"
 require "hanami/devtools/unit"
-require "hanami/cli"
+require "dry/cli"
 require_relative "./support/rspec"
 Hanami::Utils.require!("spec/support/**/*.rb")

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -1,17 +1,17 @@
 #!/usr/bin/env ruby
 $LOAD_PATH.unshift __dir__ + '/../../lib'
-require 'hanami/cli'
+require 'dry/cli'
 
 module Foo
   module CLI
     module Commands
-      extend Hanami::CLI::Registry
+      extend Dry::CLI::Registry
 
-      class Command < Hanami::CLI::Command
+      class Command < Dry::CLI::Command
       end
 
       module Assets
-        class Precompile < Hanami::CLI::Command
+        class Precompile < Dry::CLI::Command
           desc "Precompile assets for deployment"
 
           example [
@@ -23,7 +23,7 @@ module Foo
         end
       end
 
-      class Console < Hanami::CLI::Command
+      class Console < Dry::CLI::Command
         desc "Starts Foo console"
         option :engine, desc: "Force a console engine", values: %w[irb pry ripl]
 
@@ -38,35 +38,35 @@ module Foo
       end
 
       module DB
-        class Apply < Hanami::CLI::Command
+        class Apply < Dry::CLI::Command
           desc "Migrate, dump the SQL schema, and delete the migrations (experimental)"
 
           def call(*)
           end
         end
 
-        class Console < Hanami::CLI::Command
+        class Console < Dry::CLI::Command
           desc "Starts a database console"
 
           def call(*)
           end
         end
 
-        class Create < Hanami::CLI::Command
+        class Create < Dry::CLI::Command
           desc "Create the database (only for development/test)"
 
           def call(*)
           end
         end
 
-        class Drop < Hanami::CLI::Command
+        class Drop < Dry::CLI::Command
           desc "Drop the database (only for development/test)"
 
           def call(*)
           end
         end
 
-        class Migrate < Hanami::CLI::Command
+        class Migrate < Dry::CLI::Command
           desc "Migrate the database"
           argument :version, desc: "The target version of the migration (see `foo db version`)"
 
@@ -79,21 +79,21 @@ module Foo
           end
         end
 
-        class Prepare < Hanami::CLI::Command
+        class Prepare < Dry::CLI::Command
           desc "Drop, create, and migrate the database (only for development/test)"
 
           def call(*)
           end
         end
 
-        class Version < Hanami::CLI::Command
+        class Version < Dry::CLI::Command
           desc "Print the current migrated version"
 
           def call(*)
           end
         end
 
-        class Rollback < Hanami::CLI::Command
+        class Rollback < Dry::CLI::Command
           desc "Rollback the database"
 
           argument :steps, desc: "Number of versions to rollback", default: 1
@@ -105,7 +105,7 @@ module Foo
       end
 
       module Destroy
-        class Action < Hanami::CLI::Command
+        class Action < Dry::CLI::Command
           desc "Destroy an action from app"
 
           example [
@@ -121,7 +121,7 @@ module Foo
           end
         end
 
-        class App < Hanami::CLI::Command
+        class App < Dry::CLI::Command
           desc "Destroy an app"
 
           argument :app, required: true, desc: "The application name (eg. `web`)"
@@ -134,7 +134,7 @@ module Foo
           end
         end
 
-        class Mailer < Hanami::CLI::Command
+        class Mailer < Dry::CLI::Command
           desc "Destroy a mailer"
 
           argument :mailer, required: true, desc: "The mailer name (eg. `welcome`)"
@@ -147,7 +147,7 @@ module Foo
           end
         end
 
-        class Migration < Hanami::CLI::Command
+        class Migration < Dry::CLI::Command
           desc "Destroy a migration"
 
           argument :migration, required: true, desc: "The migration name (eg. `create_users`)"
@@ -160,7 +160,7 @@ module Foo
           end
         end
 
-        class Model < Hanami::CLI::Command
+        class Model < Dry::CLI::Command
           desc "Destroy a model"
 
           argument :model, required: true, desc: "The model name (eg. `user`)"
@@ -175,7 +175,7 @@ module Foo
       end
 
       module Generate
-        class Action < Hanami::CLI::Command
+        class Action < Dry::CLI::Command
           desc "Generate an action for app"
 
           example [
@@ -198,7 +198,7 @@ module Foo
           end
         end
 
-        class App < Hanami::CLI::Command
+        class App < Dry::CLI::Command
           desc "Generate an app"
 
           argument :app, required: true, desc: "The application name (eg. `web`)"
@@ -213,7 +213,7 @@ module Foo
           end
         end
 
-        class Mailer < Hanami::CLI::Command
+        class Mailer < Dry::CLI::Command
           desc "Generate a mailer"
 
           argument :mailer, required: true, desc: "The mailer name (eg. `welcome`)"
@@ -233,7 +233,7 @@ module Foo
           end
         end
 
-        class Migration < Hanami::CLI::Command
+        class Migration < Dry::CLI::Command
           desc "Generate a migration"
 
           argument :migration, required: true, desc: "The migration name (eg. `create_users`)"
@@ -246,7 +246,7 @@ module Foo
           end
         end
 
-        class Model < Hanami::CLI::Command
+        class Model < Dry::CLI::Command
           desc "Generate a model"
 
           argument :model, required: true, desc: "Model name (eg. `user`)"
@@ -262,7 +262,7 @@ module Foo
           end
         end
 
-        class Secret < Hanami::CLI::Command
+        class Secret < Dry::CLI::Command
           desc "Generate session secret"
 
           argument :app, desc: "The application name (eg. `web`)"
@@ -278,7 +278,7 @@ module Foo
         end
       end
 
-      class New < Hanami::CLI::Command
+      class New < Dry::CLI::Command
         desc "Generate a new Foo project"
         argument :project, required: true
 
@@ -302,14 +302,14 @@ module Foo
         end
       end
 
-      class Routes < Hanami::CLI::Command
+      class Routes < Dry::CLI::Command
         desc "Print routes"
 
         def call(*)
         end
       end
 
-      class Server < Hanami::CLI::Command
+      class Server < Dry::CLI::Command
         desc "Start Foo server (only for development)"
 
         option :server,         desc: "Force a server engine (eg, webrick, puma, thin, etc..)"
@@ -334,7 +334,7 @@ module Foo
         end
       end
 
-      class Version < Hanami::CLI::Command
+      class Version < Dry::CLI::Command
         desc "Print Foo version"
 
         def call(*)
@@ -342,7 +342,7 @@ module Foo
         end
       end
 
-      class Exec < Hanami::CLI::Command
+      class Exec < Dry::CLI::Command
         desc "Execute a task"
 
         argument :task, desc: "Task to execute", type: :string, required: true
@@ -353,13 +353,13 @@ module Foo
         end
       end
 
-      class Hello < Hanami::CLI::Command
+      class Hello < Dry::CLI::Command
         def call(*)
           raise NotImplementedError
         end
       end
 
-      class Greeting < Hanami::CLI::Command
+      class Greeting < Dry::CLI::Command
         argument :response, default: "Hello World"
 
         option :person
@@ -369,7 +369,7 @@ module Foo
         end
       end
 
-      class VariadicArguments < Hanami::CLI::Command
+      class VariadicArguments < Dry::CLI::Command
         desc "accept multiple arguments at the end of the command"
 
         def call(**options)
@@ -377,7 +377,7 @@ module Foo
         end
       end
 
-      class MandatoryAndVariadicArguments < Hanami::CLI::Command
+      class MandatoryAndVariadicArguments < Dry::CLI::Command
         desc "require one command and accept multiple unused arguments"
 
         argument :first, desc: 'mandatory first argument', required: true
@@ -388,7 +388,7 @@ module Foo
         end
       end
 
-      class MandatoryOptionsAndVariadicArguments < Hanami::CLI::Command
+      class MandatoryOptionsAndVariadicArguments < Dry::CLI::Command
         desc "require one command, accept options and multiple unused arguments"
 
         argument :first, desc: 'mandatory first argument', required: true
@@ -404,7 +404,7 @@ module Foo
       end
 
       module Sub
-        class Command < Hanami::CLI::Command
+        class Command < Dry::CLI::Command
           def call(*)
             raise NotImplementedError
           end
@@ -458,7 +458,7 @@ Foo::CLI::Commands.register "variadic with-mandatory-and-options", Foo::CLI::Com
 module Foo
   module Webpack
     module CLI
-      class Generate < Hanami::CLI::Command
+      class Generate < Dry::CLI::Command
         desc "Generate webpack configuration"
 
         option :apps, desc: "Generate webpack apps", type: :array
@@ -468,7 +468,7 @@ module Foo
         end
       end
 
-      class Hello < Hanami::CLI::Command
+      class Hello < Dry::CLI::Command
         desc "Print a greeting"
 
         def call(*)
@@ -476,7 +476,7 @@ module Foo
         end
       end
 
-      class SubCommand < Hanami::CLI::Command
+      class SubCommand < Dry::CLI::Command
         desc "Override a subcommand"
 
         def call(**)
@@ -484,7 +484,7 @@ module Foo
         end
       end
 
-      class CallbacksCommand < Hanami::CLI::Command
+      class CallbacksCommand < Dry::CLI::Command
         desc "Command with callbacks"
         argument :dir, required: true
         option :url
@@ -568,5 +568,5 @@ Foo::CLI::Commands.after("callbacks",  Callbacks::AfterClass)
 Foo::CLI::Commands.before("callbacks", Callbacks::Before.new)
 Foo::CLI::Commands.after("callbacks",  Callbacks::After.new)
 
-cli = Hanami::CLI.new(Foo::CLI::Commands)
+cli = Dry::CLI.new(Foo::CLI::Commands)
 cli.call

--- a/spec/support/fixtures/registry.rb
+++ b/spec/support/fixtures/registry.rb
@@ -1,9 +1,9 @@
 module Bar
   module CLI
     module Commands
-      extend Hanami::CLI::Registry
+      extend Dry::CLI::Registry
 
-      class Alpha < Hanami::CLI::Command
+      class Alpha < Dry::CLI::Command
         def call(*)
         end
       end

--- a/spec/unit/dry/cli/errors_spec.rb
+++ b/spec/unit/dry/cli/errors_spec.rb
@@ -1,8 +1,8 @@
-RSpec.describe Hanami::CLI do
+RSpec.describe Dry::CLI do
   describe "UnkwnownCommandError" do
     it "shows deprecation message" do
       expect do
-        Hanami::CLI::UnkwnownCommandError.new(:foo)
+        Dry::CLI::UnkwnownCommandError.new(:foo)
       end.to output(include("UnkwnownCommandError is deprecated, please use UnknownCommandError")).to_stderr
     end
   end

--- a/spec/unit/dry/cli/registry_spec.rb
+++ b/spec/unit/dry/cli/registry_spec.rb
@@ -1,10 +1,10 @@
-RSpec.describe Hanami::CLI::Registry do
+RSpec.describe Dry::CLI::Registry do
   describe ".before" do
     context "when command can't be found" do
       it "raises error" do
         expect do
           Bar::CLI::Commands.before("pixel") { puts "hello" }
-        end.to raise_error(Hanami::CLI::UnknownCommandError, "unknown command: `pixel'")
+        end.to raise_error(Dry::CLI::UnknownCommandError, "unknown command: `pixel'")
       end
     end
 
@@ -14,7 +14,7 @@ RSpec.describe Hanami::CLI::Registry do
 
         expect do
           Bar::CLI::Commands.before("alpha", callback)
-        end.to raise_error(Hanami::CLI::InvalidCallbackError, "expected `#{callback.inspect}' to respond to `#call'")
+        end.to raise_error(Dry::CLI::InvalidCallbackError, "expected `#{callback.inspect}' to respond to `#call'")
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe Hanami::CLI::Registry do
 
         expect do
           Bar::CLI::Commands.before("alpha", callback)
-        end.to raise_error(Hanami::CLI::InvalidCallbackError, "expected `#{callback.inspect}' to respond to `#initialize' with arity 0")
+        end.to raise_error(Dry::CLI::InvalidCallbackError, "expected `#{callback.inspect}' to respond to `#initialize' with arity 0")
       end
     end
   end
@@ -34,7 +34,7 @@ RSpec.describe Hanami::CLI::Registry do
       it "raises error" do
         expect do
           Bar::CLI::Commands.after("peta") { puts "hello" }
-        end.to raise_error(Hanami::CLI::UnknownCommandError, "unknown command: `peta'")
+        end.to raise_error(Dry::CLI::UnknownCommandError, "unknown command: `peta'")
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe Hanami::CLI::Registry do
 
         expect do
           Bar::CLI::Commands.after("alpha", callback)
-        end.to raise_error(Hanami::CLI::InvalidCallbackError, "expected `#{callback.inspect}' to respond to `#call'")
+        end.to raise_error(Dry::CLI::InvalidCallbackError, "expected `#{callback.inspect}' to respond to `#call'")
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe Hanami::CLI::Registry do
 
         expect do
           Bar::CLI::Commands.after("alpha", callback)
-        end.to raise_error(Hanami::CLI::InvalidCallbackError, "expected `#{callback.inspect}' to respond to `#initialize' with arity 0")
+        end.to raise_error(Dry::CLI::InvalidCallbackError, "expected `#{callback.inspect}' to respond to `#initialize' with arity 0")
       end
     end
   end

--- a/spec/unit/dry/cli/version_spec.rb
+++ b/spec/unit/dry/cli/version_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe "Dry::CLI::VERSION" do
+  it "exposes version" do
+    expect(Dry::CLI::VERSION).to eq("0.3.1")
+  end
+end

--- a/spec/unit/hanami/cli/version_spec.rb
+++ b/spec/unit/hanami/cli/version_spec.rb
@@ -1,5 +1,0 @@
-RSpec.describe "Hanami::CLI::VERSION" do
-  it "exposes version" do
-    expect(Hanami::CLI::VERSION).to eq("0.3.1")
-  end
-end


### PR DESCRIPTION
This is the №1 step to transfer Hanami CLI under Dry namespace. Some badges are outdated and needs to be updated after gem will be pushed to RubyGems.