### PR TITLE
Removing Hanami devtool dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,4 @@ gem 'hanami-utils', '~> 1.3', require: false,
                               git: 'https://github.com/hanami/utils.git',
                               branch: 'master'
 
-gem 'hanami-devtools', require: false, git: 'https://github.com/hanami/devtools.git'
-
 gem 'ossy', github: 'solnic/ossy', branch: 'master', platform: :mri

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ General purpose Command Line Interface (CLI) framework for Ruby.
 ## Status
 
 [![Gem Version](https://badge.fury.io/rb/hanami-cli.svg)](https://badge.fury.io/rb/hanami-cli)
-[![TravisCI](https://travis-ci.org/dry-rb/dry-cli.svg?branch=master)](https://travis-ci.org/dry-rb/dry-cli)
-[![CircleCI](https://circleci.com/gh/hanami/cli/tree/master.svg?style=svg)](https://circleci.com/gh/hanami/cli/tree/master)
-[![Test Coverage](https://codecov.io/gh/dry-rb/dry-cli/branch/master/graph/badge.svg)](https://codecov.io/gh/dry-rb/dry-cli)
+[![Maintainability](https://api.codeclimate.com/v1/badges/bb83c42b0a9e6a088832/maintainability)](https://codeclimate.com/github/dry-rb/dry-cli/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/bb83c42b0a9e6a088832/test_coverage)](https://codeclimate.com/github/dry-rb/dry-cli/test_coverage)
 [![Depfu](https://badges.depfu.com/badges/2c1bc076f16c6b5508334c44b5800362/overview.svg)](https://depfu.com/github/hanami/cli?project=Bundler)
 [![Inline Docs](http://inch-ci.org/github/hanami/cli.svg)](http://inch-ci.org/github/hanami/cli)
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,6 @@
 require 'rake'
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
-require 'hanami/devtools/rake_tasks'
 
 namespace :spec do
   RSpec::Core::RakeTask.new(:unit) do |task|

--- a/dry-cli.gemspec
+++ b/dry-cli.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.6', '< 3'
   spec.add_development_dependency 'rake',  '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.7'
+  spec.add_development_dependency 'simplecov', '~> 0.17.1'
 end

--- a/lib/dry/cli.rb
+++ b/lib/dry/cli.rb
@@ -76,7 +76,7 @@ module Dry
     # @param result [Dry::CLI::CommandRegistry::LookupResult]
     # @param out [IO] sta output
     #
-    # @return [Array<Hanami:CLI::Command, Array>] returns an array where the
+    # @return [Array<Dry:CLI::Command, Array>] returns an array where the
     #   first element is a command and the second one is the list of arguments
     #
     # @since 0.1.0

--- a/script/ci
+++ b/script/ci
@@ -41,16 +41,11 @@ run_test() {
   SIMPLECOV_COMMAND_NAME=$hash bundle exec rspec $test
 }
 
-upload_code_coverage() {
-  bundle exec rake codecov:upload
-}
-
 main() {
   prepare_build &&
     print_ruby_version &&
-    # run_unit_tests &&
-    run_integration_tests &&
-    upload_code_coverage
+    run_unit_tests &&
+    run_integration_tests
 }
 
 main

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ end
 
 $LOAD_PATH.unshift 'lib'
 require 'hanami/utils'
-require 'hanami/devtools/unit'
 require 'dry/cli'
 require_relative './support/rspec'
+Hanami::Utils.require!('spec/unit')
 Hanami::Utils.require!('spec/support/**/*.rb')


### PR DESCRIPTION
Since there is no usage of codecov in dry-rb, the rake task to upload is no longer needed.