### PR TITLE
Removing hanami-utils from dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,4 @@ unless ENV['CI']
   gem 'yard',   require: false
 end
 
-gem 'hanami-utils', '~> 1.3', require: false,
-                              git: 'https://github.com/hanami/utils.git',
-                              branch: 'master'
-
 gem 'ossy', github: 'solnic/ossy', branch: 'master', platform: :mri

--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -567,7 +567,7 @@ cli.call
 
 The `foo-bar` gem enhances `hello` command with callbacks:
 
-```
+```ruby
 Foo::CLI::Commands.before("hello") { |args| puts "debug: #{args.inspect}" } # syntax 1
 Foo::CLI::Commands.after "hello", &->(args) { puts "bye, #{args.fetch(:name)}" } # syntax 2
 ```

--- a/dry-cli.gemspec
+++ b/dry-cli.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'concurrent-ruby', '~> 1.0'
-  spec.add_dependency 'hanami-utils',    '~> 1.3'
+  spec.add_dependency 'dry-inflector',   '~> 0.2'
 
   spec.add_development_dependency 'bundler', '>= 1.6', '< 3'
   spec.add_development_dependency 'rake',  '~> 13.0'

--- a/lib/dry/cli.rb
+++ b/lib/dry/cli.rb
@@ -15,6 +15,7 @@ module Dry
     require 'dry/cli/parser'
     require 'dry/cli/usage'
     require 'dry/cli/banner'
+    require 'dry/cli/inflector'
 
     # Check if command
     #

--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -104,7 +104,7 @@ module Dry
       # rubocop:disable Metrics/AbcSize
       def self.extended_command_options(command)
         result = command.options.map do |option|
-          name = Hanami::Utils::String.dasherize(option.name)
+          name = Inflector.dasherize(option.name)
           name = if option.boolean?
                    "[no-]#{name}"
                  else

--- a/lib/dry/cli/command_registry.rb
+++ b/lib/dry/cli/command_registry.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'concurrent/hash'
-require 'hanami/utils/callbacks'
 
 module Dry
   class CLI
@@ -111,8 +110,8 @@ module Dry
           @aliases  = Concurrent::Hash.new
           @command  = nil
 
-          @before_callbacks = Hanami::Utils::Callbacks::Chain.new
-          @after_callbacks = Hanami::Utils::Callbacks::Chain.new
+          @before_callbacks = Chain.new
+          @after_callbacks = Chain.new
         end
 
         # @since 0.1.0
@@ -204,6 +203,36 @@ module Dry
         # @api private
         def after_callbacks
           @node.after_callbacks
+        end
+      end
+
+      # Callbacks chain
+      #
+      # @since 0.4.0
+      # @api private
+      class Chain
+        # @since 0.4.0
+        # @api private
+        attr_reader :chain
+
+        # @since 0.4.0
+        # @api private
+        def initialize
+          @chain = Set.new
+        end
+
+        # @since 0.4.0
+        # @api private
+        def append(&callback)
+          chain.add(callback)
+        end
+
+        # @since 0.4.0
+        # @api private
+        def run(context, *args)
+          chain.each do |callback|
+            context.instance_exec(*args, &callback)
+          end
         end
       end
     end

--- a/lib/dry/cli/errors.rb
+++ b/lib/dry/cli/errors.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'hanami/utils/deprecation'
-
 module Dry
   # General purpose Command Line Interface (CLI) framework for Ruby
   #

--- a/lib/dry/cli/inflector.rb
+++ b/lib/dry/cli/inflector.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'dry/inflector'
+
+module Dry
+  class CLI
+    Inflector = Dry::Inflector.new
+  end
+end

--- a/lib/dry/cli/option.rb
+++ b/lib/dry/cli/option.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'hanami/utils/string'
-
 module Dry
   class CLI
     # Command line option
@@ -90,7 +88,7 @@ module Dry
       #
       # rubocop:disable Metrics/AbcSize
       def parser_options
-        dasherized_name = Hanami::Utils::String.dasherize(name)
+        dasherized_name = Inflector.dasherize(name)
         parser_options  = []
 
         if boolean?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,8 +9,9 @@ if ENV['COVERAGE']
 end
 
 $LOAD_PATH.unshift 'lib'
-require 'hanami/utils'
 require 'dry/cli'
 require_relative './support/rspec'
-Hanami::Utils.require!('spec/unit')
-Hanami::Utils.require!('spec/support/**/*.rb')
+
+%w[support unit].each do |dir|
+  Dir[File.join(Dir.pwd, 'spec', dir, '**', '*.rb')].each { |file| require_relative file }
+end

--- a/spec/unit/dry/cli/utils/files_spec.rb
+++ b/spec/unit/dry/cli/utils/files_spec.rb
@@ -2,7 +2,6 @@
 
 require 'dry/cli/utils/files'
 require 'securerandom'
-require 'hanami/utils/io'
 
 RSpec.describe Dry::CLI::Utils::Files do
   let(:root) { Pathname.new(Dir.pwd).join('tmp', SecureRandom.uuid).tap(&:mkpath) }


### PR DESCRIPTION
So there were only 4 usages of hanami/utils/something in the project:
1. *hanami/utils/deprecation* — that is what I forgot to remove when removed the deprecated error
2. *hanami/utils* to use `require!` — replaced with 3-liner to require all files in folders
3. *hanami/utils/string* — both of usages of `dasherize` —  replaced with `Dry::Inflector.new.daserize` calls. Default config of inflector works perfectly against current specs and actually instantiate only 2 objects at the runtime.
4. *hanami/utils/callbacks* — replaced with fully compatible, but small implementation of Chain. It implements only 2 methods of simplified `append` and `run` from `Callbacks::Chain`.