### PR TITLE
Resolves Issue #46: Short style bug

### DIFF
--- a/lib/dry/cli/inflector.rb
+++ b/lib/dry/cli/inflector.rb
@@ -10,7 +10,7 @@ module Dry
       def self.dasherize(input)
         return nil unless input
 
-        input.to_s.downcase.gsub(/[[[:space:]]_]/, "-")
+        input.to_s.downcase.gsub(/[[[:space:]]_]/, '-')
       end
     end
   end

--- a/lib/dry/cli/option.rb
+++ b/lib/dry/cli/option.rb
@@ -100,7 +100,7 @@ module Dry
 
         parser_options << Array if array?
         parser_options << values if values
-        parser_options.unshift(alias_name) unless alias_name.nil?
+        parser_options.unshift(*alias_name) if aliases.any?
         parser_options << desc if desc
         parser_options
       end
@@ -111,7 +111,7 @@ module Dry
       # @since 0.1.0
       # @api private
       def alias_name
-        aliases.join(' ') if aliases.any?
+        aliases.map { |name| "-#{name} VALUE" }
       end
     end
 

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -46,6 +46,9 @@ RSpec.shared_examples 'Commands' do |cli|
     it 'a param using alias' do
       output = capture_output { cli.call(arguments: %w[server -p 1234]) }
       expect(output).to eq("server - {:code_reloading=>true, :port=>\"1234\"}\n")
+
+      output = capture_output { cli.call(arguments: %w[server -p1234]) }
+      expect(output).to eq("server - {:code_reloading=>true, :port=>\"1234\"}\n")
     end
 
     it 'a param with unknown param' do

--- a/spec/unit/dry/cli/inflector_spec.rb
+++ b/spec/unit/dry/cli/inflector_spec.rb
@@ -7,20 +7,20 @@ RSpec.describe Dry::CLI::Inflector do
     end
 
     it 'downcases input' do
-      expect(described_class.dasherize("Dry")).to eq("dry")
-      expect(described_class.dasherize("CLI")).to eq("cli")
+      expect(described_class.dasherize('Dry')).to eq('dry')
+      expect(described_class.dasherize('CLI')).to eq('cli')
     end
 
     it 'replaces spaces with dashes' do
-      expect(described_class.dasherize("Command Line Interface")).to eq("command-line-interface")
+      expect(described_class.dasherize('Command Line Interface')).to eq('command-line-interface')
     end
 
     it 'replaces underscores with dashes' do
-      expect(described_class.dasherize("fast_code_reloading")).to eq("fast-code-reloading")
+      expect(described_class.dasherize('fast_code_reloading')).to eq('fast-code-reloading')
     end
 
     it 'accepts any object that respond to #to_s' do
-      expect(described_class.dasherize(:dry)).to eq("dry")
+      expect(described_class.dasherize(:dry)).to eq('dry')
     end
   end
 end


### PR DESCRIPTION
Default behaviour in optparse for aliases of optional params is to be passed without separation.

```sh
$ cli the-command -ahello
```

In a way to pass it with a space, then we need to pass it correctly to optparse.

```ruby
require 'dry/cli'

module MyCommands
  extend Dry::CLI::Registry

  class TheCommand < Dry::CLI::Command
    option :aaa, aliases: ['a'], default: 'aaa-default', desc: 'aaa'
    option :abc, default: 'abc-default', desc: 'abc'

    def call(**opts)
      puts opts.inspect
    end
  end

  register 'the-command', TheCommand
end

cli = Dry::CLI.new(MyCommands)
cli.call(arguments: %w[the-command -a hello])

# => {:aaa=>"hello", :abc=>"abc-default"}
```