### PR TITLE
Removing command_name from Command properties

### DIFF
--- a/lib/dry/cli.rb
+++ b/lib/dry/cli.rb
@@ -89,12 +89,13 @@ module Dry
     # @api private
     def parse(result, out)
       command = result.command
+      names = result.names
       return [command, result.arguments] unless command?(command)
 
       result = Parser.call(command, result.arguments, result.names)
 
       if result.help?
-        Banner.call(command, out)
+        Banner.call(command, out, names)
         exit(0)
       end
 

--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -16,14 +16,15 @@ module Dry
       #
       # @since 0.1.0
       # @api private
-      def self.call(command, out)
+      def self.call(command, out, names)
+        full_command_name = full_command_name(names)
         output = [
-          command_name(command),
-          command_name_and_arguments(command),
+          command_name(full_command_name),
+          command_name_and_arguments(command, full_command_name),
           command_description(command),
           command_arguments(command),
           command_options(command),
-          command_examples(command)
+          command_examples(command, full_command_name)
         ].compact.join("\n")
 
         out.puts output
@@ -31,22 +32,22 @@ module Dry
 
       # @since 0.1.0
       # @api private
-      def self.command_name(command)
-        "Command:\n  #{full_command_name(command)}"
+      def self.command_name(name)
+        "Command:\n  #{name}"
       end
 
       # @since 0.1.0
       # @api private
-      def self.command_name_and_arguments(command)
-        "\nUsage:\n  #{full_command_name(command)}#{arguments(command)}"
+      def self.command_name_and_arguments(command, name)
+        "\nUsage:\n  #{name}#{arguments(command)}"
       end
 
       # @since 0.1.0
       # @api private
-      def self.command_examples(command)
+      def self.command_examples(command, name)
         return if command.examples.empty?
 
-        "\nExamples:\n#{command.examples.map { |example| "  #{full_command_name(command)} #{example}" }.join("\n")}" # rubocop:disable Metrics/LineLength
+        "\nExamples:\n#{command.examples.map { |example| "  #{name} #{example}" }.join("\n")}" # rubocop:disable Metrics/LineLength
       end
 
       # @since 0.1.0
@@ -73,8 +74,8 @@ module Dry
 
       # @since 0.1.0
       # @api private
-      def self.full_command_name(command)
-        ProgramName.call(command.command_name)
+      def self.full_command_name(names)
+        ProgramName.call(names)
       end
 
       # @since 0.1.0

--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -352,16 +352,6 @@ module Dry
         required_arguments
         optional_arguments
       ] => 'self.class'
-
-      # @since 0.1.0
-      # @api private
-      attr_reader :command_name
-
-      # @since 0.1.0
-      # @api private
-      def initialize(command_name:, **)
-        @command_name = command_name
-      end
     end
   end
 end

--- a/lib/dry/cli/command_registry.rb
+++ b/lib/dry/cli/command_registry.rb
@@ -17,9 +17,9 @@ module Dry
 
       # @since 0.1.0
       # @api private
-      def set(name, command, aliases, **options)
+      def set(name, command, aliases)
         node = @root
-        command = command_for(name, command, **options)
+        command = command.new if command
         name.split(/[[:space:]]/).each do |token|
           node = node.put(node, token)
         end
@@ -59,18 +59,6 @@ module Dry
         end
 
         result
-      end
-
-      private
-
-      # @since 0.1.0
-      # @api private
-      def command_for(name, command, **options)
-        if command.nil?
-          command
-        else
-          command.new(command_name: name, **options)
-        end
       end
 
       # Node of the registry

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -32,7 +32,7 @@ module Dry
         parsed_options = command.default_params.merge(parsed_options)
         parse_required_params(command, arguments, names, parsed_options)
       rescue ::OptionParser::ParseError
-        Result.failure("Error: \"#{command.command_name}\" was called with arguments \"#{original_arguments.join(' ')}\"") # rubocop:disable Metrics/LineLength
+        Result.failure("Error: \"#{names.last}\" was called with arguments \"#{original_arguments.join(' ')}\"") # rubocop:disable Metrics/LineLength
       end
 
       # @since 0.1.0

--- a/lib/dry/cli/registry.rb
+++ b/lib/dry/cli/registry.rb
@@ -74,7 +74,7 @@ module Dry
       #       end
       #     end
       #   end
-      def register(name, command = nil, aliases: [], **options, &block)
+      def register(name, command = nil, aliases: [], &block)
         if block_given?
           prefix = Prefix.new(@commands, name, aliases)
           if block.arity.zero?
@@ -83,7 +83,7 @@ module Dry
             yield(prefix)
           end
         else
-          @commands.set(name, command, aliases, **options)
+          @commands.set(name, command, aliases)
         end
       end
 
@@ -313,9 +313,9 @@ module Dry
         # @since 0.1.0
         #
         # @see Dry::CLI::Registry#register
-        def register(name, command, aliases: [], **options)
+        def register(name, command, aliases: [])
           command_name = "#{prefix} #{name}"
-          registry.set(command_name, command, aliases, **options)
+          registry.set(command_name, command, aliases)
         end
 
         private


### PR DESCRIPTION
This PR resolves dependency of Command to have some name, which is actually needed only for banner and is part of Registry.
This also allows testing commands in isolation from the registry.

And now commands can play with Dry DI