### PR TITLE
Fix aliases for boolean options bug

### DIFF
--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -110,8 +110,7 @@ module Dry
                  else
                    "#{name}=VALUE"
                  end
-
-          name = "#{name}, #{option.aliases.map { |a| a.start_with?('--') ? "#{a}=VALUE" : "#{a} VALUE" }.join(', ')}" unless option.aliases.empty? # rubocop:disable Metrics/LineLength
+          name = "#{name}, #{option.alias_names.join(', ')}" if option.aliases.any?
           name = "  --#{name.ljust(30)}"
           name = "#{name}\t# #{option.desc}"
           name = "#{name}, default: #{option.default.inspect}" unless option.default.nil?

--- a/lib/dry/cli/option.rb
+++ b/lib/dry/cli/option.rb
@@ -99,17 +99,20 @@ module Dry
 
         parser_options << Array if array?
         parser_options << values if values
-        parser_options.unshift(*alias_name) if aliases.any?
+        parser_options.unshift(*alias_names) if aliases.any?
         parser_options << desc if desc
         parser_options
       end
 
-      private
-
       # @since 0.1.0
       # @api private
-      def alias_name
-        aliases.map { |name| "-#{name} VALUE" }
+      def alias_names
+        aliases
+          .map { |name| name.gsub(/^-{1,2}/, '') }
+          .compact
+          .uniq
+          .map { |name| name.size == 1 ? "-#{name}" : "--#{name}" }
+          .map { |name| boolean? ? name : "#{name} VALUE" }
       end
     end
 

--- a/spec/support/fixtures/shared_commands.rb
+++ b/spec/support/fixtures/shared_commands.rb
@@ -293,7 +293,7 @@ module Commands
 
     option :server,         desc: 'Force a server engine (eg, webrick, puma, thin, etc..)'
     option :host,           desc: 'The host address to bind to'
-    option :port,           desc: 'The port to run the server on', aliases: ['-p']
+    option :port,           desc: 'The port to run the server on', aliases: ['-p', 'p', '--p']
     option :debug,          desc: 'Turn on debug output'
     option :warn,           desc: 'Turn on warnings'
     option :daemonize,      desc: 'Daemonize the server'
@@ -379,6 +379,18 @@ module Commands
       puts "url: #{options[:url]}"
       puts "method: #{options[:method]}"
       puts "Unused Arguments: #{options[:args].join(', ')}"
+    end
+  end
+
+  class OptionsWithAliases < Dry::CLI::Command
+    desc 'Accepts options with aliases'
+
+    option :url, desc: 'The action URL', aliases: %w[-u u --u]
+    option :flag, desc: 'The flag', type: :boolean, aliases: %w[f]
+    option :opt, desc: 'The opt', type: :boolean, aliases: %w[o], default: false
+
+    def call(options)
+      puts "options with aliases - #{options.inspect}"
     end
   end
 

--- a/spec/support/fixtures/with_block.rb
+++ b/spec/support/fixtures/with_block.rb
@@ -19,6 +19,7 @@ WithBlock = Dry::CLI.new do |cli|
   cli.register 'greeting',    Commands::Greeting
   cli.register 'sub command', Commands::Sub::Command
 
+  cli.register 'options-with-aliases',                Commands::OptionsWithAliases
   cli.register 'variadic default',                    Commands::VariadicArguments
   cli.register 'variadic with-mandatory',             Commands::MandatoryAndVariadicArguments
   cli.register 'variadic with-mandatory-and-options', Commands::MandatoryOptionsAndVariadicArguments

--- a/spec/support/fixtures/with_registry.rb
+++ b/spec/support/fixtures/with_registry.rb
@@ -49,6 +49,7 @@ module Foo
       register 'greeting',    ::Commands::Greeting
       register 'sub command', ::Commands::Sub::Command
 
+      register 'options-with-aliases',                ::Commands::OptionsWithAliases
       register 'variadic default',                    ::Commands::VariadicArguments
       register 'variadic with-mandatory',             ::Commands::MandatoryAndVariadicArguments        # rubocop:disable Metrics/LineLength
       register 'variadic with-mandatory-and-options', ::Commands::MandatoryOptionsAndVariadicArguments # rubocop:disable Metrics/LineLength

--- a/spec/support/fixtures/with_zero_arity_block.rb
+++ b/spec/support/fixtures/with_zero_arity_block.rb
@@ -19,6 +19,7 @@ WithZeroArityBlock = Dry.CLI do
   register 'greeting',    Commands::Greeting
   register 'sub command', Commands::Sub::Command
 
+  register 'options-with-aliases',                Commands::OptionsWithAliases
   register 'variadic default',                    Commands::VariadicArguments
   register 'variadic with-mandatory',             Commands::MandatoryAndVariadicArguments
   register 'variadic with-mandatory-and-options', Commands::MandatoryOptionsAndVariadicArguments

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -44,11 +44,20 @@ RSpec.shared_examples 'Commands' do |cli|
     end
 
     it 'a param using alias' do
-      output = capture_output { cli.call(arguments: %w[server -p 1234]) }
-      expect(output).to eq("server - {:code_reloading=>true, :port=>\"1234\"}\n")
+      output = capture_output { cli.call(arguments: %w[options-with-aliases -u test]) }
+      expect(output).to eq("options with aliases - {:opt=>false, :url=>\"test\"}\n")
 
-      output = capture_output { cli.call(arguments: %w[server -p1234]) }
-      expect(output).to eq("server - {:code_reloading=>true, :port=>\"1234\"}\n")
+      output = capture_output { cli.call(arguments: %w[options-with-aliases -utest]) }
+      expect(output).to eq("options with aliases - {:opt=>false, :url=>\"test\"}\n")
+
+      output = capture_output { cli.call(arguments: %w[options-with-aliases -f -u test]) }
+      expect(output).to eq("options with aliases - {:opt=>false, :flag=>true, :url=>\"test\"}\n")
+
+      output = capture_output { cli.call(arguments: %w[options-with-aliases -o]) }
+      expect(output).to eq("options with aliases - {:opt=>true}\n")
+
+      output = capture_output { cli.call(arguments: %w[options-with-aliases -of]) }
+      expect(output).to eq("options with aliases - {:opt=>true, :flag=>true}\n")
     end
 
     it 'a param with unknown param' do

--- a/spec/support/shared_examples/rendering.rb
+++ b/spec/support/shared_examples/rendering.rb
@@ -19,6 +19,7 @@ RSpec.shared_examples 'Rendering' do |cli|
         #{cmd} greeting [RESPONSE]
         #{cmd} hello                               # Print a greeting
         #{cmd} new PROJECT                         # Generate a new Foo project
+        #{cmd} options-with-aliases                # Accepts options with aliases
         #{cmd} routes                              # Print routes
         #{cmd} server                              # Start Foo server (only for development)
         #{cmd} sub [SUBCOMMAND]
@@ -76,6 +77,7 @@ RSpec.shared_examples 'Rendering' do |cli|
         #{cmd} greeting [RESPONSE]
         #{cmd} hello                               # Print a greeting
         #{cmd} new PROJECT                         # Generate a new Foo project
+        #{cmd} options-with-aliases                # Accepts options with aliases
         #{cmd} routes                              # Print routes
         #{cmd} server                              # Start Foo server (only for development)
         #{cmd} sub [SUBCOMMAND]
@@ -101,6 +103,7 @@ RSpec.shared_examples 'Rendering' do |cli|
         #{cmd} greeting [RESPONSE]
         #{cmd} hello                               # Print a greeting
         #{cmd} new PROJECT                         # Generate a new Foo project
+        #{cmd} options-with-aliases                # Accepts options with aliases
         #{cmd} routes                              # Print routes
         #{cmd} server                              # Start Foo server (only for development)
         #{cmd} sub [SUBCOMMAND]
@@ -145,25 +148,23 @@ RSpec.shared_examples 'Rendering' do |cli|
   end
 
   it 'prints list options when calling help' do
-    output = capture_output { cli.call(arguments: %w[console --help]) }
+    output = capture_output { cli.call(arguments: %w[options-with-aliases --help]) }
 
     expected = <<~DESC
       Command:
-        #{cmd} console
+        #{cmd} options-with-aliases
 
       Usage:
-        #{cmd} console
+        #{cmd} options-with-aliases
 
       Description:
-        Starts Foo console
+        Accepts options with aliases
 
       Options:
-        --engine=VALUE                  	# Force a console engine: (irb/pry/ripl)
+        --url=VALUE, -u VALUE           	# The action URL
+        --[no-]flag, -f                 	# The flag
+        --[no-]opt, -o                  	# The opt, default: false
         --help, -h                      	# Print this help
-
-      Examples:
-        #{cmd} console              # Uses the bundled engine
-        #{cmd} console --engine=pry # Force to use Pry
     DESC
 
     expect(output).to eq(expected)


### PR DESCRIPTION
This PR fixes aliases for options, mainly.
So what was the bug previously, where aliases mapped in to a string. 
And to explicitly say that CLI expect value after SPACE, we need to form string like that:
```
- aliases.join(' ')
+ aliases.map { |name| "-#{name} VALUE" }
```
And it fixed initial problem: https://github.com/dry-rb/dry-cli/pull/68/files

Though it is not working for boolean options where there is no value for an option. Its appearance is enough to understand the value.

So i fixed it that way:
1. aliases '-p', 'p', '--p' — are treated as the same, because they are singular letter and CLI expect -p flag. (
2. words are prefixed with `--`, you can not pass option `-port`, only `--port` (https://www.gnu.org/prep/standards/html_node/Command_002dLine-Interfaces.html)
3. banner is fixed as well

There is one more thing I found out. Combining options works perfect!


