### PR TITLE
Fix deprecation warning about keyword arguments in ruby 2.7

### DIFF
--- a/lib/dry/cli.rb
+++ b/lib/dry/cli.rb
@@ -62,7 +62,7 @@ module Dry
         command, args = parse(result, out)
 
         result.before_callbacks.run(command, args)
-        command.call(args)
+        command.call(**args)
         result.after_callbacks.run(command, args)
       else
         usage(result, out)

--- a/spec/support/fixtures/shared_commands.rb
+++ b/spec/support/fixtures/shared_commands.rb
@@ -308,7 +308,7 @@ module Commands
       '--no-code-reloading # Disable code reloading'
     ]
 
-    def call(options)
+    def call(**options)
       puts "server - #{options.inspect}"
     end
   end
@@ -389,7 +389,7 @@ module Commands
     option :flag, desc: 'The flag', type: :boolean, aliases: %w[f]
     option :opt, desc: 'The opt', type: :boolean, aliases: %w[o], default: false
 
-    def call(options)
+    def call(**options)
       puts "options with aliases - #{options.inspect}"
     end
   end


### PR DESCRIPTION
Running specs under Ruby 2.7 produces lots and lots of deprecation warnings:

> Warning: Using the last argument as keyword parameters is deprecated;
> maybe ** should be added to the call.

This is because we expect the command function to include keyword arguments, but automatic de-structuring of a hash to keyword arguments is targeted to be removed in a future version.

The fix is to explicitly de-structure the hash to keyword args with the double splat operator.

(See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)

Changing the caller to use a double splat operator fixes this warning, but introduces a new one under ruby 2.6:
    
> warning: in `call': the last argument was passed as a single Hash
> although a splat keyword arguments here.
    
To fix this, we need to ensure that the call definitions in the specs explicitly accept additional keyword arguments.

Not sure if it's possible to write a test for a deprecation warning, but the cli/command test suite passes successfully and without warnings now under both 2.6 and 2.7