### PR TITLE
Ability to pass command along with registry

### DIFF
--- a/dry-cli.gemspec
+++ b/dry-cli.gemspec
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # this file is managed by dry-rb/devtools project
 
 lib = File.expand_path('lib', __dir__)
@@ -7,12 +8,12 @@ require 'dry/cli/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'dry-cli'
-  spec.authors       = ["Luca Guidi"]
-  spec.email         = ["me@lucaguidi.com"]
+  spec.authors       = ['Luca Guidi']
+  spec.email         = ['me@lucaguidi.com']
   spec.license       = 'MIT'
   spec.version       = Dry::CLI::VERSION.dup
 
-  spec.summary       = "Common framework to build command line interfaces with Ruby"
+  spec.summary       = 'Common framework to build command line interfaces with Ruby'
   spec.description   = spec.summary
   spec.homepage      = 'https://dry-rb.org/gems/dry-cli'
   spec.files         = Dir['CHANGELOG.md', 'LICENSE', 'README.md', 'dry-cli.gemspec', 'lib/**/*']
@@ -26,10 +27,10 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4.0'
 
   # to update dependencies edit project.yml
-  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
+  spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
 
-  spec.add_development_dependency "bundler", ">= 1.6", "< 3"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.7"
-  spec.add_development_dependency "simplecov", "~> 0.17.1"
+  spec.add_development_dependency 'bundler', '>= 1.6', '< 3'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.7'
+  spec.add_development_dependency 'simplecov', '~> 0.17.1'
 end

--- a/lib/dry/cli/command_registry.rb
+++ b/lib/dry/cli/command_registry.rb
@@ -19,13 +19,12 @@ module Dry
       # @api private
       def set(name, command, aliases)
         node = @root
-        command = command.new if command
         name.split(/[[:space:]]/).each do |token|
           node = node.put(node, token)
         end
 
         node.aliases!(aliases)
-        node.leaf!(command) unless command.nil?
+        node.leaf!(command) if command
 
         nil
       end

--- a/spec/integration/single_command_spec.rb
+++ b/spec/integration/single_command_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Single command' do
+  context 'with command' do
+    let(:cmd) { 'baz' }
+
+    it 'shows usage' do
+      output = `baz`
+      expect(output).to eq(
+        "ERROR: \"#{cmd}\" was called with no arguments\nUsage: \"#{cmd} MANDATORY_ARG\"\n"
+      )
+    end
+
+    it 'shows help' do
+      output = `baz -h`
+      expected_output = <<~OUTPUT
+        Command:
+          #{cmd}
+
+        Usage:
+          #{cmd} MANDATORY_ARG [OPTIONAL_ARG]
+
+        Description:
+          Baz command line interface
+
+        Arguments:
+          MANDATORY_ARG       	# REQUIRED Mandatory argument
+          OPTIONAL_ARG        	# Optional argument (has to have default value in call method)
+
+        Options:
+          --option-one=VALUE, -1 VALUE    	# Option one
+          --[no-]boolean-option, -b       	# Option boolean
+          --option-with-default=VALUE, -d VALUE	# Option default, default: "test"
+          --help, -h                      	# Print this help
+      OUTPUT
+      expect(output).to eq(expected_output)
+    end
+
+    it 'with option_one' do
+      output = `baz first_arg --option_one=test2`
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
+        "Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
+      )
+    end
+
+    it 'with combination of aliases' do
+      output = `baz first_arg -bd test3`
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
+        "Options: {:option_with_default=>\"test3\", :boolean_option=>true}\n"
+      )
+    end
+  end
+end

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # this file is managed by dry-rb/devtools
 
 if ENV['COVERAGE'] == 'true'

--- a/spec/support/fixtures/baz
+++ b/spec/support/fixtures/baz
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift __dir__ + '/../../lib'
+require 'dry/cli'
+
+require_relative 'baz_command'
+
+Dry.CLI(Baz::CLI).call

--- a/spec/support/fixtures/baz_command.rb
+++ b/spec/support/fixtures/baz_command.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Baz
+  class CLI < Dry::CLI::Command
+    desc 'Baz command line interface'
+    argument :mandatory_arg, required: true, aliases: %w[m], desc: 'Mandatory argument'
+    argument :optional_arg, aliases: %w[o],
+                            desc: 'Optional argument (has to have default value in call method)'
+    option :option_one, aliases: %w[1], desc: 'Option one'
+    option :boolean_option, aliases: %w[b], desc: 'Option boolean', type: :boolean
+    option :option_with_default, aliases: %w[d], desc: 'Option default', default: 'test'
+
+    def call(mandatory_arg:, optional_arg: 'optional_arg', **options)
+      puts "mandatory_arg: #{mandatory_arg}. " \
+             "optional_arg: #{optional_arg}. " \
+             "Options: #{options.inspect}"
+    end
+  end
+end

--- a/spec/support/warnings.rb
+++ b/spec/support/warnings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # this file is managed by dry-rb/devtools project
 
 require 'warning'

--- a/spec/unit/dry/cli/cli_spec.rb
+++ b/spec/unit/dry/cli/cli_spec.rb
@@ -1,24 +1,120 @@
 # frozen_string_literal: true
 
 RSpec.describe 'CLI' do
-  context 'with registry' do
-    include_examples 'Commands', WithRegistry
-    include_examples 'Rendering', WithRegistry
-    include_examples 'Subcommands', WithRegistry
-    include_examples 'Third-party gems', WithRegistry
+  context 'when registry' do
+    context 'passing module' do
+      include_examples 'Commands', WithRegistry
+      include_examples 'Rendering', WithRegistry
+      include_examples 'Subcommands', WithRegistry
+      include_examples 'Third-party gems', WithRegistry
+    end
+
+    context 'passing block' do
+      include_examples 'Commands', WithBlock
+      include_examples 'Rendering', WithBlock
+      include_examples 'Subcommands', WithBlock
+      include_examples 'Third-party gems', WithBlock
+    end
+
+    context 'passing block with no arguments' do
+      include_examples 'Commands', WithZeroArityBlock
+      include_examples 'Rendering', WithZeroArityBlock
+      include_examples 'Subcommands', WithZeroArityBlock
+      include_examples 'Third-party gems', WithZeroArityBlock
+    end
   end
 
-  context 'with block' do
-    include_examples 'Commands', WithBlock
-    include_examples 'Rendering', WithBlock
-    include_examples 'Subcommands', WithBlock
-    include_examples 'Third-party gems', WithBlock
-  end
+  context 'with command' do
+    let(:cli) { Dry.CLI(Baz::CLI) }
+    let(:cmd) { File.basename($PROGRAM_NAME, File.extname($PROGRAM_NAME)) }
 
-  context 'with zero arity block' do
-    include_examples 'Commands', WithZeroArityBlock
-    include_examples 'Rendering', WithZeroArityBlock
-    include_examples 'Subcommands', WithZeroArityBlock
-    include_examples 'Third-party gems', WithZeroArityBlock
+    it 'shows help' do
+      output = capture_output { cli.call(arguments: ['-h']) }
+      expected_output = <<~OUTPUT
+        Command:
+          #{cmd}
+
+        Usage:
+          #{cmd} MANDATORY_ARG [OPTIONAL_ARG]
+
+        Description:
+          Baz command line interface
+
+        Arguments:
+          MANDATORY_ARG       	# REQUIRED Mandatory argument
+          OPTIONAL_ARG        	# Optional argument (has to have default value in call method)
+
+        Options:
+          --option-one=VALUE, -1 VALUE    	# Option one
+          --[no-]boolean-option, -b       	# Option boolean
+          --option-with-default=VALUE, -d VALUE	# Option default, default: "test"
+          --help, -h                      	# Print this help
+      OUTPUT
+      expect(output).to eq(expected_output)
+    end
+
+    it 'with required_argument' do
+      output = capture_output { cli.call(arguments: ['first_arg']) }
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
+      	"Options: {:option_with_default=>\"test\"}\n"
+      )
+    end
+
+    it 'with optional_arg' do
+      output = capture_output { cli.call(arguments: %w[first_arg opt_arg]) }
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: opt_arg. ' \
+      	"Options: {:option_with_default=>\"test\", :args=>[\"opt_arg\"]}\n"
+      )
+    end
+
+    it 'with option_one' do
+      output = capture_output { cli.call(arguments: %w[first_arg --option_one=test2]) }
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
+      	"Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
+      )
+    end
+
+    it 'with option_one alias' do
+      output = capture_output { cli.call(arguments: %w[first_arg -1 test2]) }
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
+      	"Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
+      )
+    end
+
+    it 'with boolean_option' do
+      output = capture_output { cli.call(arguments: %w[first_arg --boolean_option]) }
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
+      	"Options: {:option_with_default=>\"test\", :boolean_option=>true}\n"
+      )
+    end
+
+    it 'with boolean_option alias' do
+      output = capture_output { cli.call(arguments: %w[first_arg -b]) }
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
+      	"Options: {:option_with_default=>\"test\", :boolean_option=>true}\n"
+      )
+    end
+
+    it 'with option_with_default alias' do
+      output = capture_output { cli.call(arguments: %w[first_arg --option_with_default=test3]) }
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
+      	"Options: {:option_with_default=>\"test3\"}\n"
+      )
+    end
+
+    it 'with combination of aliases' do
+      output = capture_output { cli.call(arguments: %w[first_arg -bd test3]) }
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
+      	"Options: {:option_with_default=>\"test3\", :boolean_option=>true}\n"
+      )
+    end
   end
 end


### PR DESCRIPTION
From the beginning of my Dry/cli interest, I've struggled without having an ability to use dry-cli with single command. Not subcommands.

I’ve been trying to make it in different ways, and came to this solution as this one is the most simple and convinient IMHO.

You just don’t have to think what to pass, you can either pass single command or registry
So this PR allows passing `command` along with the `registry` to `dry/cli`
Just a quick example of usage inside gem:

`bin/gem_name`

```ruby
#!/usr/bin/env ruby
require 'gem_name/cli'

Dry.CLI(GemName::CLI).call
```

That easy
