### PR TITLE
Inline syntax for commands

### DIFF
--- a/lib/dry/cli/inline.rb
+++ b/lib/dry/cli/inline.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'backports/2.5.0/module/define_method' if RUBY_VERSION < '2.5'
+
+module Dry
+  class CLI
+    require 'dry/cli'
+    # Inline Syntax (aka DSL) to implement one-file applications
+    #
+    # `dry/cli/inline` is not required by default
+    # and explicit requirement of this file means that
+    # it is expected of abusing global namespace with
+    # methods below
+    #
+    # DSL consists of 5 methods:
+    # `desc`, `example`, `argument`, `option` 
+    # — are similar to methods from Command class
+    #
+    # `run` accepts a block to execute
+    #
+    # @example
+    #   require 'bundler/inline'
+    #   gemfile { gem 'dry/cli', require: 'dry/cli/inline' }
+    #
+    #   desc 'List files in a directory'
+    #   argument :path, required: false, desc: '[DIR]'
+    #   option :all, aliases: ['a'], type: :boolean
+    #
+    #   run do |path: '.', **options|
+    #     puts options.key?(:all) ? Dir.entries(path) : Dir.children(path)
+    #   end
+    #
+    #   # $ ls -a
+    #   # $ ls somepath
+    #   # $ ls somepath --all
+    # @since 0.6.x
+    module Inline
+      extend Forwardable
+
+      # AnonymousCommand
+      #
+      # @since 0.6.x
+      AnonymousCommand = Class.new(Dry::CLI::Command)
+
+      # @since 0.6.x
+      delegate %i[desc example argument option] => AnonymousCommand
+
+      # The rule of thumb for implementation of run block
+      # is that for every argument from your CLI
+      # you need to specify that as an mandatory argument for a block.
+      # Optional arguments have to have default value as ruby syntax expect them
+      #
+      # @example
+      #   argument :one
+      #   argument :two, required: false
+      #   option :three
+      #
+      #   run do |one:, two: 'default', **options|
+      #     puts one, two, options.inspect
+      #   end
+      #
+      # @since 0.6.x
+      def run(arguments: ARGV, out: $stdout)
+        command = AnonymousCommand
+        command.define_method(:call) do |*args|
+          yield(*args)
+        end
+
+        Dry.CLI(command).call(arguments: arguments, out: out)
+      end
+    end
+  end
+end
+
+include Dry::CLI::Inline # rubocop:disable Style/MixinUsage

--- a/spec/integration/inline_spec.rb
+++ b/spec/integration/inline_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Inline' do
+  context 'with command' do
+    let(:cmd) { 'inline' }
+
+    it 'shows help' do
+      output = `inline -h`
+      expected_output = <<~OUTPUT
+        Command:
+          inline
+
+        Usage:
+          inline MANDATORY_ARG [OPTIONAL_ARG]
+
+        Description:
+          Baz command line interface
+
+        Arguments:
+          MANDATORY_ARG       	# REQUIRED Mandatory argument
+          OPTIONAL_ARG        	# Optional argument (has to have default value in call method)
+
+        Options:
+          --option-one=VALUE, -1 VALUE    	# Option one
+          --[no-]boolean-option, -b       	# Option boolean
+          --option-with-default=VALUE, -d VALUE	# Option default, default: "test"
+          --help, -h                      	# Print this help
+      OUTPUT
+      expect(output).to eq(expected_output)
+    end
+
+    it 'with option_one', if: RUBY_VERSION < '2.4' do
+      output = `inline first_arg --option-one=test2 -bd test3`
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
+        'Options: {:option_with_default=>"test3", :option_one=>"test2", :boolean_option=>true}' \
+        "\n"
+      )
+    end
+
+    it 'with underscored option_one', if: RUBY_VERSION >= '2.4' do
+      output = `inline first_arg -1 test2 -bd test3`
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
+        'Options: {:option_with_default=>"test3", :option_one=>"test2", :boolean_option=>true}' \
+        "\n"
+      )
+    end
+  end
+end

--- a/spec/support/fixtures/inline
+++ b/spec/support/fixtures/inline
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift __dir__ + '/../../../lib'
+require 'dry/cli'
+require_relative '../../../lib/dry/cli/inline'
+
+desc 'Baz command line interface'
+argument :mandatory_arg, required: true, aliases: %w[m], desc: 'Mandatory argument'
+argument :optional_arg, aliases: %w[o],
+                        desc: 'Optional argument (has to have default value in call method)'
+option :option_one, aliases: %w[1], desc: 'Option one'
+option :boolean_option, aliases: %w[b], desc: 'Option boolean', type: :boolean
+option :option_with_default, aliases: %w[d], desc: 'Option default', default: 'test'
+
+run do |mandatory_arg:, optional_arg: 'optional_arg', **options|
+  puts "mandatory_arg: #{mandatory_arg}. " \
+         "optional_arg: #{optional_arg}. " \
+         "Options: #{options.inspect}"
+end


### PR DESCRIPTION
`dry/cli/inline` is not required by default and explicit requirement of this file means that it is expected of abusing global namespace with methods below

Example: ls
```ruby
#!/usr/bin/env ruby
require 'bundler/inline'
gemfile do
  gem 'dry-cli', require: 'dry/cli/inline', 
                 github: 'dry-rb/dry-cli',                   # sure you don't need these lines
                 branch: 'feature/inline-syntax-for-command' # but I leave them for testing purposes
end

desc 'List files in a directory'
argument :path, required: false, desc: '[DIR]'
option :all, aliases: ['a'], type: :boolean

run do |path: '.', **options|
  puts options.key?(:all) ? Dir.entries(path) : Dir.children(path)
end
```

```
$ chmod +x ls
$ ./ls
```