### PR TITLE
Fixing loadpath for ruby 2.3.8 and rspec 3.9.1

### DIFF
--- a/spec/support/fixtures/baz
+++ b/spec/support/fixtures/baz
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift __dir__ + '/../../lib'
+$LOAD_PATH.unshift __dir__ + 'lib'
+$LOAD_PATH.unshift __dir__ + '/../../../lib'
 require 'dry/cli'
 
 require_relative 'baz_command'

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -2,7 +2,8 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/LineLength
-$LOAD_PATH.unshift __dir__ + '/../../lib'
+$LOAD_PATH.unshift __dir__ + 'lib'
+$LOAD_PATH.unshift __dir__ + '/../../../lib'
 require 'dry/cli'
 
 module Foo


### PR DESCRIPTION
Reason why rspec failed is that it could not load dry/cli inside fixtured CLI's