### PR TITLE
Revert "Fixing loadpath for ruby 2.3.8 and rspec 3.9.1 (#78)"

### DIFF
--- a/spec/support/fixtures/baz
+++ b/spec/support/fixtures/baz
@@ -1,8 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift __dir__ + 'lib'
-$LOAD_PATH.unshift __dir__ + '/../../../lib'
+$LOAD_PATH.unshift __dir__ + '/../../lib'
 require 'dry/cli'
 
 require_relative 'baz_command'

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -2,8 +2,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable Metrics/LineLength
-$LOAD_PATH.unshift __dir__ + 'lib'
-$LOAD_PATH.unshift __dir__ + '/../../../lib'
+$LOAD_PATH.unshift __dir__ + '/../../lib'
 require 'dry/cli'
 
 module Foo


### PR DESCRIPTION
This reverts commit 11d14fc8381b3e881c42d152a15891b6fc5c4ba5.