### PR TITLE
Revert 2.3 ruby compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ eval_gemfile 'Gemfile.devtools'
 
 gemspec
 
+gem 'backports', '~> 3.15.0', require: false
+
 unless ENV['CI']
   gem 'byebug', require: false, platforms: :mri
   gem 'yard',   require: false

--- a/lib/dry/cli/utils/files.rb
+++ b/lib/dry/cli/utils/files.rb
@@ -2,6 +2,7 @@
 
 require 'pathname'
 require 'fileutils'
+require 'backports/2.4.0/string/match' if RUBY_VERSION < '2.4'
 
 module Dry
   class CLI

--- a/spec/integration/single_command_spec.rb
+++ b/spec/integration/single_command_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Single command' do
     end
 
     it 'with option_one' do
-      output = `baz first_arg --option_one=test2`
+      output = `baz first_arg --option-one=test2`
       expect(output).to eq(
         'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
         "Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"

--- a/spec/unit/dry/cli/cli_spec.rb
+++ b/spec/unit/dry/cli/cli_spec.rb
@@ -69,11 +69,19 @@ RSpec.describe 'CLI' do
       )
     end
 
-    it 'with option_one' do
-      output = capture_output { cli.call(arguments: %w[first_arg --option_one=test2]) }
+    it 'with option_one', if: RUBY_VERSION < '2.4' do
+      output = capture_output { cli.call(arguments: %w[first_arg --option-one=test2]) }
       expect(output).to eq(
         'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
       	"Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
+      )
+    end
+
+    it 'with underscored option_one', if: RUBY_VERSION >= '2.4' do
+      output = capture_output { cli.call(arguments: %w[first_arg --option_one=test2]) }
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
+        "Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
       )
     end
 
@@ -85,11 +93,19 @@ RSpec.describe 'CLI' do
       )
     end
 
-    it 'with boolean_option' do
-      output = capture_output { cli.call(arguments: %w[first_arg --boolean_option]) }
+    it 'with boolean_option', if: RUBY_VERSION < '2.4' do
+      output = capture_output { cli.call(arguments: %w[first_arg --boolean-option]) }
       expect(output).to eq(
         'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
       	"Options: {:option_with_default=>\"test\", :boolean_option=>true}\n"
+      )
+    end
+
+    it 'with underscored boolean_option', if: RUBY_VERSION >= '2.4' do
+      output = capture_output { cli.call(arguments: %w[first_arg --boolean_option]) }
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
+        "Options: {:option_with_default=>\"test\", :boolean_option=>true}\n"
       )
     end
 
@@ -101,11 +117,19 @@ RSpec.describe 'CLI' do
       )
     end
 
-    it 'with option_with_default alias' do
-      output = capture_output { cli.call(arguments: %w[first_arg --option_with_default=test3]) }
+    it 'with option_with_default alias', if: RUBY_VERSION < '2.4' do
+      output = capture_output { cli.call(arguments: %w[first_arg --option-with-default=test3]) }
       expect(output).to eq(
         'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
       	"Options: {:option_with_default=>\"test3\"}\n"
+      )
+    end
+
+    it 'with underscoreed option_with_default alias', if: RUBY_VERSION >= '2.4' do
+      output = capture_output { cli.call(arguments: %w[first_arg --option_with_default=test3]) }
+      expect(output).to eq(
+        'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
+        "Options: {:option_with_default=>\"test3\"}\n"
       )
     end
 


### PR DESCRIPTION
Backporting `match?` for files and passed arguments for commands
