### PR TITLE
[WIP] Invoke commands to combine

### DIFF
--- a/dry-cli.gemspec
+++ b/dry-cli.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   # to update dependencies edit project.yml
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
+  spec.add_runtime_dependency "dry-effects"
 
   spec.add_development_dependency "bundler", ">= 1.6", "< 3"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/lib/dry/cli.rb
+++ b/lib/dry/cli.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'dry/effects'
 
 # Dry
 #
@@ -16,6 +17,8 @@ module Dry
     require 'dry/cli/usage'
     require 'dry/cli/banner'
     require 'dry/cli/inflector'
+
+    include Dry::Effects::Handler.Reader(:cli)
 
     # Check if command
     #
@@ -101,7 +104,7 @@ module Dry
         command, args = parse(result.command, result.arguments, result.names, out)
 
         result.before_callbacks.run(command, args)
-        command.call(**args)
+        with_cli(self) { command.call(**args) }
         result.after_callbacks.run(command, args)
       else
         usage(result, out)

--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'forwardable'
+require 'open3'
+require 'dry/cli/program_name'
 require 'concurrent/array'
 require 'dry/cli/option'
 
@@ -15,6 +17,7 @@ module Dry
       def self.inherited(base)
         super
         base.extend ClassMethods
+        base.include Dry::Effects.Reader(:cli)
       end
 
       # @since 0.1.0
@@ -352,6 +355,11 @@ module Dry
         required_arguments
         optional_arguments
       ] => 'self.class'
+
+      def invoke(command, *arguments)
+        command = [command] unless command.is_a?(Array)
+        cli.call(arguments: [*command, *arguments])
+      end
     end
   end
 end

--- a/spec/integration/commands_spec.rb
+++ b/spec/integration/commands_spec.rb
@@ -11,4 +11,9 @@ RSpec.describe 'Commands' do
       end
     end
   end
+
+  it 'calls other commands from inside call' do
+    output = `foo g scaffold Test`
+    expect(output).to eq("generate model - model: Test\ngenerate secret - app: \n")
+  end
 end

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -264,6 +264,17 @@ module Foo
             puts "generate secret - app: #{app}"
           end
         end
+
+        class Scaffold < Dry::CLI::Command
+          desc 'Generate scaffold'
+
+          argument :model, required: true, desc: 'Scaffold for model'
+
+          def call(model:)
+            invoke(%w[g model], model)
+            invoke(%w[g secret])
+          end
+        end
       end
 
       class New < Dry::CLI::Command
@@ -427,6 +438,7 @@ Foo::CLI::Commands.register 'generate', aliases: ['g'] do |prefix|
   prefix.register 'migration', Foo::CLI::Commands::Generate::Migration
   prefix.register 'model',     Foo::CLI::Commands::Generate::Model
   prefix.register 'secret',    Foo::CLI::Commands::Generate::Secret
+  prefix.register 'scaffold',  Foo::CLI::Commands::Generate::Scaffold
 end
 Foo::CLI::Commands.register 'new',     Foo::CLI::Commands::New
 Foo::CLI::Commands.register 'routes',  Foo::CLI::Commands::Routes


### PR DESCRIPTION
I'm working on idea of invoking commands from other commands to combine them together.
Say you have views, model, controller generators and you want to make a scaffold command

```ruby
module Generate
  class Scaffold < Dry::CLI::Command
    argument :model_name

    def call(model_name:)
      invoke(%w[g model], model_name)
      invoke(%w[g controller], model_name)
    end
  end

  class Model < Dry::CLI::Command
    argument :model_name

    def call(model_name:)
      invoke(%[g migration], model_name)
      some_other_model_staff
    end
  end

  class Controller < Dry::CLI::Command
    argument :model_name

    def call(model_name:)
      add_routes
      add_controller
    end

    def add_controller(model_name)
      ACTIONS.each { |action|  invoke(%[g views], model_name, action) }
      some_other_controller_staff
    end
  end
end
```
WDYT ?