### PR TITLE
Stderror introduction to any diagnostic output

### DIFF
--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -16,9 +16,9 @@ module Dry
       #
       # @since 0.1.0
       # @api private
-      def self.call(command, out, names)
+      def self.call(command, names)
         full_command_name = full_command_name(names)
-        output = [
+        [
           command_name(full_command_name),
           command_name_and_arguments(command, full_command_name),
           command_description(command),
@@ -26,8 +26,6 @@ module Dry
           command_options(command),
           command_examples(command, full_command_name)
         ].compact.join("\n")
-
-        out.puts output
       end
 
       # @since 0.1.0

--- a/lib/dry/cli/usage.rb
+++ b/lib/dry/cli/usage.rb
@@ -15,14 +15,14 @@ module Dry
 
       # @since 0.1.0
       # @api private
-      def self.call(result, out)
-        out.puts 'Commands:'
+      def self.call(result)
+        header = 'Commands:'
         max_length, commands = commands_and_arguments(result)
 
-        commands.each do |banner, node|
+        commands.map do |banner, node|
           usage = description(node.command) if node.leaf?
-          out.puts "#{justify(banner, max_length, usage)}#{usage}"
-        end
+          "#{justify(banner, max_length, usage)}#{usage}"
+        end.unshift(header).join("\n")
       end
 
       # @since 0.1.0

--- a/spec/integration/inline_spec.rb
+++ b/spec/integration/inline_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open3'
+
 RSpec.describe 'Inline' do
   context 'with command' do
     let(:cmd) { 'inline' }

--- a/spec/integration/rendering_spec.rb
+++ b/spec/integration/rendering_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require 'open3'
+
 RSpec.describe 'Rendering' do
   it 'prints available commands for unknown command' do
-    output = `foo unknown`
+    _, stderr, = Open3.capture3('foo unknown')
 
     expected = <<~DESC
       Commands:
@@ -23,6 +25,6 @@ RSpec.describe 'Rendering' do
         foo version                            # Print Foo version
     DESC
 
-    expect(output).to eq(expected)
+    expect(stderr).to eq(expected)
   end
 end

--- a/spec/integration/single_command_spec.rb
+++ b/spec/integration/single_command_spec.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
+require 'open3'
+
 RSpec.describe 'Single command' do
   context 'with command' do
     let(:cmd) { 'baz' }
 
     it 'shows usage' do
-      output = `baz`
-      expect(output).to eq(
+      _, stderr, = Open3.capture3('baz')
+      expect(stderr).to eq(
         "ERROR: \"#{cmd}\" was called with no arguments\nUsage: \"#{cmd} MANDATORY_ARG\"\n"
       )
     end

--- a/spec/integration/subcommands_spec.rb
+++ b/spec/integration/subcommands_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open3'
+
 RSpec.describe 'Subcommands' do
   context 'works with params' do
     it 'with help param' do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -15,6 +15,19 @@ module RSpec
       ensure
         $stdout = original_stdout
       end
+
+      def capture_error
+        require 'stringio'
+        error = StringIO.new
+        original_stderr = $stderr
+        $stderr = error
+        yield
+        error.string
+      rescue SystemExit
+        error.string
+      ensure
+        $stderr = original_stderr
+      end
     end
   end
 end

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -61,8 +61,8 @@ RSpec.shared_examples 'Commands' do |cli|
     end
 
     it 'a param with unknown param' do
-      output = capture_output { cli.call(arguments: %w[server --unknown 1234]) }
-      expect(output).to eq("Error: \"server\" was called with arguments \"--unknown 1234\"\n")
+      error = capture_error { cli.call(arguments: %w[server --unknown 1234]) }
+      expect(error).to eq("Error: \"server\" was called with arguments \"--unknown 1234\"\n")
     end
 
     it 'with boolean param' do
@@ -95,8 +95,8 @@ RSpec.shared_examples 'Commands' do |cli|
 
       context 'and with an unknown value passed' do
         it 'prints error' do
-          output = capture_output { cli.call(arguments: %w[console --engine=unknown]) }
-          expect(output).to eq("Error: \"console\" was called with arguments \"--engine=unknown\"\n") # rubocop:disable Metrics/LineLength
+          error = capture_error { cli.call(arguments: %w[console --engine=unknown]) }
+          expect(error).to eq("Error: \"console\" was called with arguments \"--engine=unknown\"\n") # rubocop:disable Metrics/LineLength
         end
       end
     end
@@ -143,8 +143,8 @@ RSpec.shared_examples 'Commands' do |cli|
       end
 
       it 'with unknown param' do
-        output = capture_output { cli.call(arguments: %w[new bookshelf --unknown 1234]) }
-        expect(output).to eq("Error: \"new\" was called with arguments \"bookshelf --unknown 1234\"\n") # rubocop:disable Metrics/LineLength
+        error = capture_error { cli.call(arguments: %w[new bookshelf --unknown 1234]) }
+        expect(error).to eq("Error: \"new\" was called with arguments \"bookshelf --unknown 1234\"\n") # rubocop:disable Metrics/LineLength
       end
 
       it 'no required' do
@@ -156,12 +156,12 @@ RSpec.shared_examples 'Commands' do |cli|
       end
 
       it "an error is displayed if there aren't required params" do
-        output = capture_output { cli.call(arguments: ['new']) }
-        expected_output = <<~DESC
+        error = capture_error { cli.call(arguments: ['new']) }
+        expected_error = <<~DESC
           ERROR: "#{cmd} new" was called with no arguments
           Usage: "#{cmd} new PROJECT"
         DESC
-        expect(output).to eq(expected_output)
+        expect(error).to eq(expected_error)
       end
 
       it 'with default value and using options' do

--- a/spec/support/shared_examples/rendering.rb
+++ b/spec/support/shared_examples/rendering.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples 'Rendering' do |cli|
   let(:cmd) { File.basename($PROGRAM_NAME, File.extname($PROGRAM_NAME)) }
 
   it 'prints required params' do
-    output = capture_output { cli.call }
+    error = capture_error { cli.call }
     expected = <<~DESC
       Commands:
         #{cmd} assets [SUBCOMMAND]
@@ -27,11 +27,11 @@ RSpec.shared_examples 'Rendering' do |cli|
         #{cmd} version                             # Print Foo version
     DESC
 
-    expect(output).to eq(expected)
+    expect(error).to eq(expected)
   end
 
   it 'prints required params with labels' do
-    output = capture_output { cli.call(arguments: ['destroy']) }
+    error = capture_error { cli.call(arguments: ['destroy']) }
 
     expected = <<~DESC
       Commands:
@@ -42,11 +42,11 @@ RSpec.shared_examples 'Rendering' do |cli|
         #{cmd} destroy model MODEL                          # Destroy a model
     DESC
 
-    expect(output).to eq(expected)
+    expect(error).to eq(expected)
   end
 
   it 'prints available commands for unknown subcommand' do
-    output = capture_output { cli.call(arguments: %w[generate unknown]) }
+    error = capture_error { cli.call(arguments: %w[generate unknown]) }
 
     expected = <<~DESC
       Commands:
@@ -59,11 +59,11 @@ RSpec.shared_examples 'Rendering' do |cli|
         #{cmd} generate webpack                               # Generate webpack configuration
     DESC
 
-    expect(output).to eq(expected)
+    expect(error).to eq(expected)
   end
 
   it 'prints available commands for unknown command' do
-    output = capture_output { cli.call(arguments: ['unknown']) }
+    error = capture_error { cli.call(arguments: ['unknown']) }
 
     expected = <<~DESC
       Commands:
@@ -85,11 +85,11 @@ RSpec.shared_examples 'Rendering' do |cli|
         #{cmd} version                             # Print Foo version
     DESC
 
-    expect(output).to eq(expected)
+    expect(error).to eq(expected)
   end
 
   it 'prints first level' do
-    output = capture_output { cli.call }
+    error = capture_error { cli.call }
 
     expected = <<~DESC
       Commands:
@@ -111,11 +111,11 @@ RSpec.shared_examples 'Rendering' do |cli|
         #{cmd} version                             # Print Foo version
     DESC
 
-    expect(output).to eq(expected)
+    expect(error).to eq(expected)
   end
 
   it "prints subcommand's commands" do
-    output = capture_output { cli.call(arguments: ['generate']) }
+    error = capture_error { cli.call(arguments: ['generate']) }
 
     expected = <<~DESC
       Commands:
@@ -128,11 +128,11 @@ RSpec.shared_examples 'Rendering' do |cli|
         #{cmd} generate webpack                               # Generate webpack configuration
     DESC
 
-    expect(output).to eq(expected)
+    expect(error).to eq(expected)
   end
 
   it "prints subcommand's subcommand" do
-    output = capture_output { cli.call(arguments: %w[generate application]) }
+    error = capture_error { cli.call(arguments: %w[generate application]) }
 
     expected = <<~DESC
       Commands:
@@ -144,7 +144,7 @@ RSpec.shared_examples 'Rendering' do |cli|
         #{cmd} generate secret [APP]                          # Generate session secret
         #{cmd} generate webpack                               # Generate webpack configuration
     DESC
-    expect(output).to eq(expected)
+    expect(error).to eq(expected)
   end
 
   it 'prints list options when calling help' do

--- a/spec/support/shared_examples/subcommands.rb
+++ b/spec/support/shared_examples/subcommands.rb
@@ -6,24 +6,24 @@ RSpec.shared_examples 'Subcommands' do |cli|
   let(:cmd) { File.basename($PROGRAM_NAME, File.extname($PROGRAM_NAME)) }
 
   it 'calls subcommand' do
-    output = capture_output { cli.call(arguments: %w[generate model]) }
+    error = capture_error { cli.call(arguments: %w[generate model]) }
     expected = <<~DESC
       ERROR: "#{cmd} generate model" was called with no arguments
       Usage: "#{cmd} generate model MODEL"
     DESC
 
-    expect(output).to eq(expected)
+    expect(error).to eq(expected)
   end
 
   context 'works with params' do
     it 'without params' do
-      output = capture_output { cli.call(arguments: %w[generate model]) }
+      error = capture_error { cli.call(arguments: %w[generate model]) }
       expected = <<~DESC
         ERROR: "#{cmd} generate model" was called with no arguments
         Usage: "#{cmd} generate model MODEL"
       DESC
 
-      expect(output).to eq(expected)
+      expect(error).to eq(expected)
     end
 
     it 'a param using space' do
@@ -96,23 +96,23 @@ RSpec.shared_examples 'Subcommands' do |cli|
       end
 
       it "an error is displayed if there aren't required params" do
-        output = capture_output { cli.call(arguments: %w[destroy action]) }
+        error = capture_error { cli.call(arguments: %w[destroy action]) }
         expected = <<~DESC
           ERROR: "#{cmd} destroy action" was called with no arguments
           Usage: "#{cmd} destroy action APP ACTION"
         DESC
 
-        expect(output).to eq(expected)
+        expect(error).to eq(expected)
       end
 
       it 'an error is displayed if there are some required params' do
-        output = capture_output { cli.call(arguments: %w[destroy action web]) }
+        error = capture_error { cli.call(arguments: %w[destroy action web]) }
         expected = <<~DESC
           ERROR: "#{cmd} destroy action" was called with arguments [\"web\"]
           Usage: "#{cmd} destroy action APP ACTION"
         DESC
 
-        expect(output).to eq(expected)
+        expect(error).to eq(expected)
       end
 
       context 'and a default value' do


### PR DESCRIPTION
According to Unix's best practices, all diagnostic outputs and errors should go straight to Stderr.
Banner which reacts to `-h` flag is the result of command execution, so it is a proper output and goes to output.
