### PR TITLE
Fix banner when Option is a type of Array

### DIFF
--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -105,6 +105,8 @@ module Dry
           name = Inflector.dasherize(option.name)
           name = if option.boolean?
                    "[no-]#{name}"
+                 elsif option.array?
+                   "#{name}=VALUE1,VALUE2,.."
                  else
                    "#{name}=VALUE"
                  end

--- a/spec/support/fixtures/shared_commands.rb
+++ b/spec/support/fixtures/shared_commands.rb
@@ -299,6 +299,7 @@ module Commands
     option :daemonize,      desc: 'Daemonize the server'
     option :pid,            desc: 'Path to write a pid file after daemonize'
     option :code_reloading, desc: 'Code reloading', type: :boolean, default: true
+    option :deps,           desc: 'List of extra dependencies', type: :array, default: %w[dep1 dep2]
 
     example [
       '                    # Basic usage (it uses the bundled server engine)',

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -30,17 +30,17 @@ RSpec.shared_examples 'Commands' do |cli|
   context 'works with params' do
     it 'without params' do
       output = capture_output { cli.call(arguments: ['server']) }
-      expect(output).to eq("server - {:code_reloading=>true}\n")
+      expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"]}\n")
     end
 
     it 'a param using space' do
       output = capture_output { cli.call(arguments: %w[server --server thin]) }
-      expect(output).to eq("server - {:code_reloading=>true, :server=>\"thin\"}\n")
+      expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :server=>\"thin\"}\n")
     end
 
     it 'a param using equal sign' do
       output = capture_output { cli.call(arguments: %w[server --host=localhost]) }
-      expect(output).to eq("server - {:code_reloading=>true, :host=>\"localhost\"}\n")
+      expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :host=>\"localhost\"}\n")
     end
 
     it 'a param using alias' do
@@ -67,10 +67,10 @@ RSpec.shared_examples 'Commands' do |cli|
 
     it 'with boolean param' do
       output = capture_output { cli.call(arguments: ['server']) }
-      expect(output).to eq("server - {:code_reloading=>true}\n")
+      expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"]}\n")
 
       output = capture_output { cli.call(arguments: %w[server --no-code-reloading]) }
-      expect(output).to eq("server - {:code_reloading=>false}\n")
+      expect(output).to eq("server - {:code_reloading=>false, :deps=>[\"dep1\", \"dep2\"]}\n")
     end
 
     context 'with array param' do
@@ -123,6 +123,7 @@ RSpec.shared_examples 'Commands' do |cli|
           --daemonize=VALUE               	# Daemonize the server
           --pid=VALUE                     	# Path to write a pid file after daemonize
           --[no-]code-reloading           	# Code reloading, default: true
+          --deps=VALUE1,VALUE2,..         	# List of extra dependencies, default: ["dep1", "dep2"]
           --help, -h                      	# Print this help
 
         Examples:

--- a/spec/support/shared_examples/subcommands.rb
+++ b/spec/support/shared_examples/subcommands.rb
@@ -28,17 +28,23 @@ RSpec.shared_examples 'Subcommands' do |cli|
 
     it 'a param using space' do
       output = capture_output { cli.call(arguments: %w[server --port 2306]) }
-      expect(output).to eq("server - {:code_reloading=>true, :port=>\"2306\"}\n")
+      expect(output).to eq(
+        "server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :port=>\"2306\"}\n"
+      )
     end
 
     it 'a param using equal sign' do
       output = capture_output { cli.call(arguments: %w[server --port=2306]) }
-      expect(output).to eq("server - {:code_reloading=>true, :port=>\"2306\"}\n")
+      expect(output).to eq(
+        "server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :port=>\"2306\"}\n"
+      )
     end
 
     it 'a param using alias' do
       output = capture_output { cli.call(arguments: %w[server -p 2306]) }
-      expect(output).to eq("server - {:code_reloading=>true, :port=>\"2306\"}\n")
+      expect(output).to eq(
+        "server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :port=>\"2306\"}\n"
+      )
     end
 
     it 'with help param' do


### PR DESCRIPTION
To make it clear for user, how to pass array as an value for an option, I suggest using this syntax.
Fixes https://github.com/dry-rb/dry-cli/issues/81 
