### PR TITLE
Add support for subcommands with a valid parent command

### DIFF
--- a/lib/dry/cli/command_registry.rb
+++ b/lib/dry/cli/command_registry.rb
@@ -37,12 +37,14 @@ module Dry
         node   = @root
         args   = []
         names  = []
+        valid_leaf = nil
         result = LookupResult.new(node, args, names, node.leaf?)
 
         arguments.each_with_index do |token, i|
           tmp = node.lookup(token)
 
           if tmp.nil?
+            (result = valid_leaf) && break if valid_leaf
             result = LookupResult.new(node, args, names, false)
             break
           elsif tmp.leaf?
@@ -50,7 +52,8 @@ module Dry
             names  = arguments[0..i]
             node   = tmp
             result = LookupResult.new(node, args, names, true)
-            break
+            valid_leaf = result
+            break unless tmp.children?
           else
             names  = arguments[0..i]
             node   = tmp
@@ -138,6 +141,11 @@ module Dry
         # @api private
         def leaf?
           !command.nil?
+        end
+
+        # @api private
+        def children?
+          !children.empty?
         end
       end
 

--- a/lib/dry/cli/usage.rb
+++ b/lib/dry/cli/usage.rb
@@ -30,7 +30,9 @@ module Dry
       def self.commands_and_arguments(result)
         max_length = 0
         ret        = commands(result).each_with_object({}) do |(name, node), memo|
-          args = if node.leaf?
+          args = if node.leaf? && node.children?
+                   arguments(node.command) + " ||#{SUBCOMMAND_BANNER}"
+                 elsif node.leaf?
                    arguments(node.command)
                  else
                    SUBCOMMAND_BANNER

--- a/spec/integration/rendering_spec.rb
+++ b/spec/integration/rendering_spec.rb
@@ -9,20 +9,21 @@ RSpec.describe 'Rendering' do
     expected = <<~DESC
       Commands:
         foo assets [SUBCOMMAND]
-        foo callbacks DIR                      # Command with callbacks
-        foo console                            # Starts Foo console
+        foo callbacks DIR                                           # Command with callbacks
+        foo console                                                 # Starts Foo console
         foo db [SUBCOMMAND]
         foo destroy [SUBCOMMAND]
-        foo exec TASK [DIRS]                   # Execute a task
+        foo exec TASK [DIRS]                                        # Execute a task
         foo generate [SUBCOMMAND]
         foo greeting [RESPONSE]
-        foo hello                              # Print a greeting
-        foo new PROJECT                        # Generate a new Foo project
-        foo routes                             # Print routes
-        foo server                             # Start Foo server (only for development)
+        foo hello                                                   # Print a greeting
+        foo new PROJECT                                             # Generate a new Foo project
+        foo root [NOT_A_SUBCMD] || [SUBCOMMAND]                     # root for a subcommand
+        foo routes                                                  # Print routes
+        foo server                                                  # Start Foo server (only for development)
         foo sub [SUBCOMMAND]
         foo variadic [SUBCOMMAND]
-        foo version                            # Print Foo version
+        foo version                                                 # Print Foo version
     DESC
 
     expect(stderr).to eq(expected)

--- a/spec/integration/subcommands_spec.rb
+++ b/spec/integration/subcommands_spec.rb
@@ -32,4 +32,82 @@ RSpec.describe 'Subcommands' do
       expect(output).to eq(expected)
     end
   end
+
+  context 'works with root subcommands' do
+    it 'with root command' do
+      output = `foo root --url=google`
+
+      expected = <<~DESC
+        I am not a subcommand:
+        url:google
+      DESC
+
+      expect(output).to eq(expected)
+    end
+
+    it 'with root command' do
+      output = `foo root foo`
+
+      expected = <<~DESC
+        I am not a subcommand:foo
+        url:
+      DESC
+
+      expect(output).to eq(expected)
+    end
+
+    it 'with root leaf' do
+      output = `foo root leaf`
+
+      expected = <<~DESC
+        I am a subcommand!
+      DESC
+
+      expect(output).to eq(expected)
+    end
+
+    it 'should display help for root command' do
+      output = `foo root --help`
+
+      expected = <<~DESC
+        Command:
+          foo root
+
+        Usage:
+          foo root [NOT_A_SUBCMD]
+        
+        Description:
+          root for a subcommand
+
+        Arguments:
+          NOT_A_SUBCMD        	# optional argument
+
+        Options:
+          --url=VALUE                     	# Any URL
+          --help, -h                      	# Print this help
+      DESC
+
+      expect(output).to eq(expected)
+    end
+
+    it 'should display help for subcommand' do
+      output = `foo root leaf --help`
+
+      expected = <<~DESC
+        Command:
+          foo root leaf
+
+        Usage:
+          foo root leaf
+
+        Description:
+          leaf subcommand
+
+        Options:
+          --help, -h                      	# Print this help
+      DESC
+
+      expect(output).to eq(expected)
+    end
+  end
 end

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -397,6 +397,24 @@ module Foo
           end
         end
       end
+
+      class Root < Dry::CLI::Command
+        desc 'root for a subcommand'
+        argument :not_a_subcmd, desc: 'optional argument', required: false
+        option :url, desc: 'Any URL'
+
+        def call(not_a_subcmd: nil, **options)
+          puts "I am not a subcommand:#{not_a_subcmd}"
+          puts "url:#{options[:url]}"
+        end
+
+        class Leaf < Dry::CLI::Command
+          desc 'leaf subcommand'
+          def call(*)
+            puts 'I am a subcommand!'
+          end
+        end
+      end
     end
   end
 end
@@ -437,6 +455,9 @@ Foo::CLI::Commands.register 'exec',    Foo::CLI::Commands::Exec
 Foo::CLI::Commands.register 'hello',       Foo::CLI::Commands::Hello
 Foo::CLI::Commands.register 'greeting',    Foo::CLI::Commands::Greeting
 Foo::CLI::Commands.register 'sub command', Foo::CLI::Commands::Sub::Command
+
+Foo::CLI::Commands.register 'root', Foo::CLI::Commands::Root
+Foo::CLI::Commands.register 'root leaf', Foo::CLI::Commands::Root::Leaf
 
 Foo::CLI::Commands.register 'variadic default',                    Foo::CLI::Commands::VariadicArguments
 Foo::CLI::Commands.register 'variadic with-mandatory',             Foo::CLI::Commands::MandatoryAndVariadicArguments


### PR DESCRIPTION
Subcommands are a very powerful feature in `dry-cli`. However, there is a case when you already have a parent command and want to provide extra args/options to a subcommand.

The only possibility to this now is to use a custom first argument, which leads to a lot of messy logic if your parent command and a specific subcommand are quite different.

This PR supports simple leaf logic traversal to allow configurations like this:

```Foo::CLI::Commands.register 'root', Foo::CLI::Commands::Root
Foo::CLI::Commands.register 'root leaf', Foo::CLI::Commands::Root::Leaf```

Where `root` and `root leaf` are two independent commands, both with their own implementation/arguments. The tree will try to match `root leaf` first and, if not found, will fallback to `root` (that can further process arguments/options).

In the usage mode, this will be presented as:

`foo root [ARGUMENT] || [SUBCOMMAND]`