### PR TITLE
Remove `concurrent-ruby` as runtime dependency

### DIFF
--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -36,51 +36,27 @@ module Dry
 
         # @since 0.1.0
         # @api private
-        def description
-          @_mutex.synchronize do
-            @description
-          end
-        end
+        attr_reader :description
 
         # @since 0.1.0
         # @api private
-        def examples
-          @_mutex.synchronize do
-            @examples
-          end
-        end
+        attr_reader :examples
 
         # @since 0.1.0
         # @api private
-        def arguments
-          @_mutex.synchronize do
-            @arguments
-          end
-        end
+        attr_reader :arguments
 
         # @since 0.1.0
         # @api private
-        def options
-          @_mutex.synchronize do
-            @options
-          end
-        end
+        attr_reader :options
 
         # @since 0.6.x
         # @api private
-        def subcommands
-          @_mutex.synchronize do
-            @subcommands
-          end
-        end
+        attr_reader :subcommands
 
         # @since 0.6.x
         # @api private
-        def subcommands=(value)
-          @_mutex.synchronize do
-            @subcommands = value
-          end
-        end
+        attr_writer :subcommands
       end
 
       # Set the description of the command
@@ -100,9 +76,7 @@ module Dry
       #     end
       #   end
       def self.desc(description)
-        @_mutex.synchronize do
-          @description = description
-        end
+        @description = description
       end
 
       # Describe the usage of the command
@@ -138,9 +112,7 @@ module Dry
       #   #     foo server --port=2306         # Bind to a port
       #   #     foo server --no-code-reloading # Disable code reloading
       def self.example(*examples)
-        @_mutex.synchronize do
-          @examples += examples.flatten
-        end
+        @examples += examples.flatten(1)
       end
 
       # Specify an argument
@@ -234,9 +206,7 @@ module Dry
       #   #   Options:
       #   #     --help, -h          # Print this help
       def self.argument(name, options = {})
-        @_mutex.synchronize do
-          @arguments << Argument.new(name, options)
-        end
+        @arguments << Argument.new(name, options)
       end
 
       # Command line option (aka optional argument)
@@ -350,9 +320,7 @@ module Dry
       #   # Options:
       #   #   --port=VALUE, -p VALUE
       def self.option(name, options = {})
-        @_mutex.synchronize do
-          @options << Option.new(name, options)
-        end
+        @options << Option.new(name, options)
       end
 
       # @since 0.1.0

--- a/lib/dry/cli/registry.rb
+++ b/lib/dry/cli/registry.rb
@@ -12,6 +12,7 @@ module Dry
       # @api private
       def self.extended(base)
         base.class_eval do
+          @_mutex = Mutex.new
           @commands = CommandRegistry.new
         end
       end
@@ -170,7 +171,9 @@ module Dry
       #     end
       #   end
       def before(command_name, callback = nil, &blk)
-        command(command_name).before_callbacks.append(&_callback(callback, blk))
+        @_mutex.synchronize do
+          command(command_name).before_callbacks.append(&_callback(callback, blk))
+        end
       end
 
       # Register an after callback.
@@ -256,7 +259,9 @@ module Dry
       #     end
       #   end
       def after(command_name, callback = nil, &blk)
-        command(command_name).after_callbacks.append(&_callback(callback, blk))
+        @_mutex.synchronize do
+          command(command_name).after_callbacks.append(&_callback(callback, blk))
+        end
       end
 
       # @since 0.1.0

--- a/project.yml
+++ b/project.yml
@@ -11,4 +11,3 @@ gemspec:
     - [rspec, "~> 3.7"]
     - [simplecov, "~> 0.17.1"]
   runtime_dependencies:
-    - [concurrent-ruby, "~> 1.0"]

--- a/project.yml
+++ b/project.yml
@@ -10,4 +10,3 @@ gemspec:
     - [rake, "~> 13.0"]
     - [rspec, "~> 3.7"]
     - [simplecov, "~> 0.17.1"]
-  runtime_dependencies:


### PR DESCRIPTION
## Enhancements

We recently discussed in chat about thread-safety, code loading, and if it was worth to keep `concurrent-ruby` around.

This proposal removes `concurrent-ruby`, and still keeps the thread-safety properties. It's a win-win situation, and `dry-cli` can have zero runtime gem dependencies.

---

One note: I removed `concurrent-ruby` gem from `project.yml`, IDK how to reflect this change in `dry-cli.gemspec`.