### PR TITLE
Ljust instead of tabs

### DIFF
--- a/docsite/source/commands-with-subcommands-and-params.md
+++ b/docsite/source/commands-with-subcommands-and-params.md
@@ -61,13 +61,13 @@ Description:
   Information about account
 
 Subcommands:
-  users                         	# Information about account users
+  users                           # Information about account users
 
 Arguments:
-  FORMAT              	# Output format: (long/short)
+  FORMAT                # Output format: (long/short)
 
 Options:
-  --help, -h                      	# Print this help
+  --help, -h                        # Print this help
 ```
 ```sh
 $ foo account

--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -165,10 +165,10 @@ Description:
   Print input
 
 Arguments:
-  INPUT               	# Input to print
+  INPUT                 # Input to print
 
 Options:
-  --help, -h                      	# Print this help
+  --help, -h                        # Print this help
 
 Examples:
   foo echo              # Prints 'wuh?'

--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -104,7 +104,7 @@ module Dry
       # @api private
       def self.extended_command_arguments(command)
         command.arguments.map do |argument|
-          "  #{argument.name.to_s.upcase.ljust(20)}\t# #{'REQUIRED ' if argument.required?}#{argument.desc}" # rubocop:disable Metrics/LineLength
+          "  #{argument.name.to_s.upcase.ljust(32)}  # #{'REQUIRED ' if argument.required?}#{argument.desc}" # rubocop:disable Metrics/LineLength
         end.join("\n")
       end
 
@@ -123,18 +123,18 @@ module Dry
                  end
           name = "#{name}, #{option.alias_names.join(', ')}" if option.aliases.any?
           name = "  --#{name.ljust(30)}"
-          name = "#{name}\t# #{option.desc}"
+          name = "#{name}  # #{option.desc}"
           name = "#{name}, default: #{option.default.inspect}" unless option.default.nil?
           name
         end
 
-        result << "  --#{'help, -h'.ljust(30)}\t# Print this help"
+        result << "  --#{'help, -h'.ljust(30)}  # Print this help"
         result.join("\n")
       end
 
       def self.build_subcommands_list(subcommands)
         subcommands.map do |subcommand_name, subcommand|
-          "  #{subcommand_name.ljust(30)}\t# #{subcommand.command.description}"
+          "  #{subcommand_name.ljust(32)}  # #{subcommand.command.description}"
         end.join("\n")
       end
     end

--- a/spec/integration/inline_spec.rb
+++ b/spec/integration/inline_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe 'Inline' do
           Baz command line interface
 
         Arguments:
-          MANDATORY_ARG       	# REQUIRED Mandatory argument
-          OPTIONAL_ARG        	# Optional argument (has to have default value in call method)
+          MANDATORY_ARG                     # REQUIRED Mandatory argument
+          OPTIONAL_ARG                      # Optional argument (has to have default value in call method)
 
         Options:
-          --option-one=VALUE, -1 VALUE    	# Option one
-          --[no-]boolean-option, -b       	# Option boolean
-          --option-with-default=VALUE, -d VALUE	# Option default, default: "test"
-          --help, -h                      	# Print this help
+          --option-one=VALUE, -1 VALUE      # Option one
+          --[no-]boolean-option, -b         # Option boolean
+          --option-with-default=VALUE, -d VALUE  # Option default, default: "test"
+          --help, -h                        # Print this help
       OUTPUT
       expect(output).to eq(expected_output)
     end

--- a/spec/integration/single_command_spec.rb
+++ b/spec/integration/single_command_spec.rb
@@ -26,14 +26,14 @@ RSpec.describe 'Single command' do
           Baz command line interface
 
         Arguments:
-          MANDATORY_ARG       	# REQUIRED Mandatory argument
-          OPTIONAL_ARG        	# Optional argument (has to have default value in call method)
+          MANDATORY_ARG                     # REQUIRED Mandatory argument
+          OPTIONAL_ARG                      # Optional argument (has to have default value in call method)
 
         Options:
-          --option-one=VALUE, -1 VALUE    	# Option one
-          --[no-]boolean-option, -b       	# Option boolean
-          --option-with-default=VALUE, -d VALUE	# Option default, default: "test"
-          --help, -h                      	# Print this help
+          --option-one=VALUE, -1 VALUE      # Option one
+          --[no-]boolean-option, -b         # Option boolean
+          --option-with-default=VALUE, -d VALUE  # Option default, default: "test"
+          --help, -h                        # Print this help
       OUTPUT
       expect(output).to eq(expected_output)
     end

--- a/spec/integration/subcommands_spec.rb
+++ b/spec/integration/subcommands_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe 'Subcommands' do
           Generate a model
 
         Arguments:
-          MODEL               	# REQUIRED Model name (eg. `user`)
+          MODEL                             # REQUIRED Model name (eg. `user`)
 
         Options:
-          --[no-]skip-migration           	# Skip migration, default: false
-          --help, -h                      	# Print this help
+          --[no-]skip-migration             # Skip migration, default: false
+          --help, -h                        # Print this help
 
         Examples:
           foo generate model user                  # Generate `User` entity, `UserRepository` repository, and the migration

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -115,16 +115,16 @@ RSpec.shared_examples 'Commands' do |cli|
           Start Foo server (only for development)
 
         Options:
-          --server=VALUE                  	# Force a server engine (eg, webrick, puma, thin, etc..)
-          --host=VALUE                    	# The host address to bind to
-          --port=VALUE, -p VALUE          	# The port to run the server on
-          --debug=VALUE                   	# Turn on debug output
-          --warn=VALUE                    	# Turn on warnings
-          --daemonize=VALUE               	# Daemonize the server
-          --pid=VALUE                     	# Path to write a pid file after daemonize
-          --[no-]code-reloading           	# Code reloading, default: true
-          --deps=VALUE1,VALUE2,..         	# List of extra dependencies, default: ["dep1", "dep2"]
-          --help, -h                      	# Print this help
+          --server=VALUE                    # Force a server engine (eg, webrick, puma, thin, etc..)
+          --host=VALUE                      # The host address to bind to
+          --port=VALUE, -p VALUE            # The port to run the server on
+          --debug=VALUE                     # Turn on debug output
+          --warn=VALUE                      # Turn on warnings
+          --daemonize=VALUE                 # Daemonize the server
+          --pid=VALUE                       # Path to write a pid file after daemonize
+          --[no-]code-reloading             # Code reloading, default: true
+          --deps=VALUE1,VALUE2,..           # List of extra dependencies, default: ["dep1", "dep2"]
+          --help, -h                        # Print this help
 
         Examples:
           #{cmd} server                     # Basic usage (it uses the bundled server engine)
@@ -216,14 +216,14 @@ RSpec.shared_examples 'Commands' do |cli|
           Root command with arguments and subcommands
 
         Subcommands:
-          sub-command                   	# Root command sub command
+          sub-command                       # Root command sub command
 
         Arguments:
-          ROOT_COMMAND_ARGUMENT	# REQUIRED Root command argument
+          ROOT_COMMAND_ARGUMENT             # REQUIRED Root command argument
 
         Options:
-          --root-command-option=VALUE     	# Root command option
-          --help, -h                      	# Print this help
+          --root-command-option=VALUE       # Root command option
+          --help, -h                        # Print this help
       DESC
 
       expect(output).to eq(expected)

--- a/spec/support/shared_examples/rendering.rb
+++ b/spec/support/shared_examples/rendering.rb
@@ -164,10 +164,10 @@ RSpec.shared_examples 'Rendering' do |cli|
         Accepts options with aliases
 
       Options:
-        --url=VALUE, -u VALUE           	# The action URL
-        --[no-]flag, -f                 	# The flag
-        --[no-]opt, -o                  	# The opt, default: false
-        --help, -h                      	# Print this help
+        --url=VALUE, -u VALUE             # The action URL
+        --[no-]flag, -f                   # The flag
+        --[no-]opt, -o                    # The opt, default: false
+        --help, -h                        # Print this help
     DESC
 
     expect(output).to eq(expected)

--- a/spec/support/shared_examples/subcommands.rb
+++ b/spec/support/shared_examples/subcommands.rb
@@ -61,11 +61,11 @@ RSpec.shared_examples 'Subcommands' do |cli|
           Generate a model
 
         Arguments:
-          MODEL               	# REQUIRED Model name (eg. `user`)
+          MODEL                             # REQUIRED Model name (eg. `user`)
 
         Options:
-          --[no-]skip-migration           	# Skip migration, default: false
-          --help, -h                      	# Print this help
+          --[no-]skip-migration             # Skip migration, default: false
+          --help, -h                        # Print this help
 
         Examples:
           #{cmd} generate model user                  # Generate `User` entity, `UserRepository` repository, and the migration
@@ -151,11 +151,11 @@ RSpec.shared_examples 'Subcommands' do |cli|
           Root command sub command
 
         Arguments:
-          ROOT_COMMAND_SUB_COMMAND_ARGUMENT	# REQUIRED Root command sub command argument
+          ROOT_COMMAND_SUB_COMMAND_ARGUMENT  # REQUIRED Root command sub command argument
 
         Options:
-          --root-command-sub-command-option=VALUE	# Root command sub command option
-          --help, -h                      	# Print this help
+          --root-command-sub-command-option=VALUE  # Root command sub command option
+          --help, -h                        # Print this help
       DESC
 
       expect(output).to eq(expected)

--- a/spec/unit/dry/cli/cli_spec.rb
+++ b/spec/unit/dry/cli/cli_spec.rb
@@ -41,14 +41,14 @@ RSpec.describe 'CLI' do
           Baz command line interface
 
         Arguments:
-          MANDATORY_ARG       	# REQUIRED Mandatory argument
-          OPTIONAL_ARG        	# Optional argument (has to have default value in call method)
+          MANDATORY_ARG                     # REQUIRED Mandatory argument
+          OPTIONAL_ARG                      # Optional argument (has to have default value in call method)
 
         Options:
-          --option-one=VALUE, -1 VALUE    	# Option one
-          --[no-]boolean-option, -b       	# Option boolean
-          --option-with-default=VALUE, -d VALUE	# Option default, default: "test"
-          --help, -h                      	# Print this help
+          --option-one=VALUE, -1 VALUE      # Option one
+          --[no-]boolean-option, -b         # Option boolean
+          --option-with-default=VALUE, -d VALUE  # Option default, default: "test"
+          --help, -h                        # Print this help
       OUTPUT
       expect(output).to eq(expected_output)
     end
@@ -57,7 +57,7 @@ RSpec.describe 'CLI' do
       output = capture_output { cli.call(arguments: ['first_arg']) }
       expect(output).to eq(
         'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
-      	"Options: {:option_with_default=>\"test\"}\n"
+        "Options: {:option_with_default=>\"test\"}\n"
       )
     end
 
@@ -65,7 +65,7 @@ RSpec.describe 'CLI' do
       output = capture_output { cli.call(arguments: %w[first_arg opt_arg]) }
       expect(output).to eq(
         'mandatory_arg: first_arg. optional_arg: opt_arg. ' \
-      	"Options: {:option_with_default=>\"test\", :args=>[\"opt_arg\"]}\n"
+        "Options: {:option_with_default=>\"test\", :args=>[\"opt_arg\"]}\n"
       )
     end
 
@@ -73,7 +73,7 @@ RSpec.describe 'CLI' do
       output = capture_output { cli.call(arguments: %w[first_arg --option-one=test2]) }
       expect(output).to eq(
         'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
-      	"Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
+        "Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
       )
     end
 
@@ -89,7 +89,7 @@ RSpec.describe 'CLI' do
       output = capture_output { cli.call(arguments: %w[first_arg -1 test2]) }
       expect(output).to eq(
         'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
-      	"Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
+        "Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
       )
     end
 
@@ -97,7 +97,7 @@ RSpec.describe 'CLI' do
       output = capture_output { cli.call(arguments: %w[first_arg --boolean-option]) }
       expect(output).to eq(
         'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
-      	"Options: {:option_with_default=>\"test\", :boolean_option=>true}\n"
+        "Options: {:option_with_default=>\"test\", :boolean_option=>true}\n"
       )
     end
 
@@ -113,7 +113,7 @@ RSpec.describe 'CLI' do
       output = capture_output { cli.call(arguments: %w[first_arg -b]) }
       expect(output).to eq(
         'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
-      	"Options: {:option_with_default=>\"test\", :boolean_option=>true}\n"
+        "Options: {:option_with_default=>\"test\", :boolean_option=>true}\n"
       )
     end
 
@@ -121,7 +121,7 @@ RSpec.describe 'CLI' do
       output = capture_output { cli.call(arguments: %w[first_arg --option-with-default=test3]) }
       expect(output).to eq(
         'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
-      	"Options: {:option_with_default=>\"test3\"}\n"
+        "Options: {:option_with_default=>\"test3\"}\n"
       )
     end
 
@@ -137,7 +137,7 @@ RSpec.describe 'CLI' do
       output = capture_output { cli.call(arguments: %w[first_arg -bd test3]) }
       expect(output).to eq(
         'mandatory_arg: first_arg. optional_arg: optional_arg. ' \
-      	"Options: {:option_with_default=>\"test3\", :boolean_option=>true}\n"
+        "Options: {:option_with_default=>\"test3\", :boolean_option=>true}\n"
       )
     end
   end


### PR DESCRIPTION
It is just desired thing to have, usage of `ljust` instead of `\t` helps works pretty same, and helpful for development. Since ruby is the language with space indentation, it is always a nightmare, when you prepare specs, where tabs should be.