### PR TITLE
Banner and Parser small refactoring

### DIFF
--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -233,7 +233,7 @@ generated tests - framework: rspec
 
 ```sh
 $ foo generate test --framework=unknown
-Error: "test" was called with arguments "--framework=unknown"
+Error: "foo generate test" was called with arguments "--framework=unknown"
 ```
 
 ### Boolean options

--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -233,7 +233,7 @@ generated tests - framework: rspec
 
 ```sh
 $ foo generate test --framework=unknown
-Error: "foo generate test" was called with arguments "--framework=unknown"
+ERROR: "foo generate test" was called with arguments "--framework=unknown"
 ```
 
 ### Boolean options

--- a/docsite/source/options.html.md
+++ b/docsite/source/options.html.md
@@ -47,5 +47,5 @@ Performing a request (mode: http2)
 
 ```sh
 $ foo request --mode=unknown
-Error: "request" was called with arguments "--mode=unknown"
+Error: "foo request" was called with arguments "--mode=unknown"
 ```

--- a/docsite/source/options.html.md
+++ b/docsite/source/options.html.md
@@ -47,5 +47,5 @@ Performing a request (mode: http2)
 
 ```sh
 $ foo request --mode=unknown
-Error: "foo request" was called with arguments "--mode=unknown"
+ERROR: "foo request" was called with arguments "--mode=unknown"
 ```

--- a/lib/dry/cli.rb
+++ b/lib/dry/cli.rb
@@ -131,10 +131,12 @@ module Dry
     # @since 0.6.0
     # @api private
     def parse(command, arguments, names)
-      result = Parser.call(command, arguments, names)
+      prog_name = ProgramName.call(names)
+
+      result = Parser.call(command, arguments, prog_name)
 
       if result.help?
-        out.puts Banner.call(command, names)
+        out.puts Banner.call(command, prog_name)
         exit(0)
       end
 

--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -16,16 +16,15 @@ module Dry
       #
       # @since 0.1.0
       # @api private
-      def self.call(command, names)
-        full_command_name = full_command_name(names)
+      def self.call(command, name)
         [
-          command_name(full_command_name),
-          command_name_and_arguments(command, full_command_name),
+          command_name(name),
+          command_name_and_arguments(command, name),
           command_description(command),
           command_subcommands(command),
           command_arguments(command),
           command_options(command),
-          command_examples(command, full_command_name)
+          command_examples(command, name)
         ].compact.join("\n")
       end
 
@@ -79,12 +78,6 @@ module Dry
       # @api private
       def self.command_options(command)
         "\nOptions:\n#{extended_command_options(command)}"
-      end
-
-      # @since 0.1.0
-      # @api private
-      def self.full_command_name(names)
-        ProgramName.call(names)
       end
 
       # @since 0.1.0

--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -247,7 +247,7 @@ module Dry
       #   # starting console (engine: pry)
       #
       #   # $ foo console --engine=foo
-      #   # Error: Invalid param provided
+      #   # ERROR: Invalid param provided
       #
       # @example Description
       #   require "dry/cli"

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -13,7 +13,7 @@ module Dry
       # @since 0.1.0
       # @api private
       #
-      def self.call(command, arguments, names)
+      def self.call(command, arguments, prog_name)
         original_arguments = arguments.dup
         parsed_options = {}
 
@@ -30,22 +30,16 @@ module Dry
         end.parse!(arguments)
 
         parsed_options = command.default_params.merge(parsed_options)
-        parse_required_params(command, arguments, names, parsed_options)
+        parse_required_params(command, arguments, prog_name, parsed_options)
       rescue ::OptionParser::ParseError
-        Result.failure("Error: \"#{names.last}\" was called with arguments \"#{original_arguments.join(' ')}\"") # rubocop:disable Metrics/LineLength
-      end
-
-      # @since 0.1.0
-      # @api private
-      def self.full_command_name(names)
-        ProgramName.call(names)
+        Result.failure("Error: \"#{prog_name}\" was called with arguments \"#{original_arguments.join(' ')}\"") # rubocop:disable Metrics/LineLength
       end
 
       # @since 0.1.0
       # @api private
       #
       # rubocop:disable Metrics/AbcSize
-      def self.parse_required_params(command, arguments, names, parsed_options)
+      def self.parse_required_params(command, arguments, prog_name, parsed_options)
         parsed_params          = match_arguments(command.arguments, arguments)
         parsed_required_params = match_arguments(command.required_arguments, arguments)
         all_required_params_satisfied = command.required_arguments.all? { |param| !parsed_required_params[param.name].nil? } # rubocop:disable Metrics/LineLength
@@ -54,18 +48,17 @@ module Dry
 
         unless all_required_params_satisfied
           parsed_required_params_values = parsed_required_params.values.compact
-          command_name = full_command_name(names)
 
-          usage = "\nUsage: \"#{full_command_name(names)} #{command.required_arguments.map(&:description_name).join(' ')}" # rubocop:disable Metrics/LineLength
+          usage = "\nUsage: \"#{prog_name} #{command.required_arguments.map(&:description_name).join(' ')}" # rubocop:disable Metrics/LineLength
 
-          usage += " | #{command_name} SUBCOMMAND" if command.subcommands.any?
+          usage += " | #{prog_name} SUBCOMMAND" if command.subcommands.any?
 
           usage += '"'
 
           if parsed_required_params_values.empty?
-            return Result.failure("ERROR: \"#{command_name}\" was called with no arguments#{usage}") # rubocop:disable Metrics/LineLength
+            return Result.failure("ERROR: \"#{prog_name}\" was called with no arguments#{usage}") # rubocop:disable Metrics/LineLength
           else
-            return Result.failure("ERROR: \"#{command_name}\" was called with arguments #{parsed_required_params_values}#{usage}") # rubocop:disable Metrics/LineLength
+            return Result.failure("ERROR: \"#{prog_name}\" was called with arguments #{parsed_required_params_values}#{usage}") # rubocop:disable Metrics/LineLength
           end
         end
 

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -32,7 +32,7 @@ module Dry
         parsed_options = command.default_params.merge(parsed_options)
         parse_required_params(command, arguments, prog_name, parsed_options)
       rescue ::OptionParser::ParseError
-        Result.failure("Error: \"#{prog_name}\" was called with arguments \"#{original_arguments.join(' ')}\"") # rubocop:disable Metrics/LineLength
+        Result.failure("ERROR: \"#{prog_name}\" was called with arguments \"#{original_arguments.join(' ')}\"") # rubocop:disable Metrics/LineLength
       end
 
       # @since 0.1.0

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -62,7 +62,7 @@ RSpec.shared_examples 'Commands' do |cli|
 
     it 'a param with unknown param' do
       error = capture_error { cli.call(arguments: %w[server --unknown 1234]) }
-      expect(error).to eq("Error: \"rspec server\" was called with arguments \"--unknown 1234\"\n")
+      expect(error).to eq("ERROR: \"rspec server\" was called with arguments \"--unknown 1234\"\n")
     end
 
     it 'with boolean param' do
@@ -96,7 +96,7 @@ RSpec.shared_examples 'Commands' do |cli|
       context 'and with an unknown value passed' do
         it 'prints error' do
           error = capture_error { cli.call(arguments: %w[console --engine=unknown]) }
-          expect(error).to eq("Error: \"rspec console\" was called with arguments \"--engine=unknown\"\n") # rubocop:disable Metrics/LineLength
+          expect(error).to eq("ERROR: \"rspec console\" was called with arguments \"--engine=unknown\"\n") # rubocop:disable Metrics/LineLength
         end
       end
     end
@@ -145,7 +145,7 @@ RSpec.shared_examples 'Commands' do |cli|
 
       it 'with unknown param' do
         error = capture_error { cli.call(arguments: %w[new bookshelf --unknown 1234]) }
-        expect(error).to eq("Error: \"rspec new\" was called with arguments \"bookshelf --unknown 1234\"\n") # rubocop:disable Metrics/LineLength
+        expect(error).to eq("ERROR: \"rspec new\" was called with arguments \"bookshelf --unknown 1234\"\n") # rubocop:disable Metrics/LineLength
       end
 
       it 'no required' do

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -62,7 +62,7 @@ RSpec.shared_examples 'Commands' do |cli|
 
     it 'a param with unknown param' do
       error = capture_error { cli.call(arguments: %w[server --unknown 1234]) }
-      expect(error).to eq("Error: \"server\" was called with arguments \"--unknown 1234\"\n")
+      expect(error).to eq("Error: \"rspec server\" was called with arguments \"--unknown 1234\"\n")
     end
 
     it 'with boolean param' do
@@ -96,7 +96,7 @@ RSpec.shared_examples 'Commands' do |cli|
       context 'and with an unknown value passed' do
         it 'prints error' do
           error = capture_error { cli.call(arguments: %w[console --engine=unknown]) }
-          expect(error).to eq("Error: \"console\" was called with arguments \"--engine=unknown\"\n") # rubocop:disable Metrics/LineLength
+          expect(error).to eq("Error: \"rspec console\" was called with arguments \"--engine=unknown\"\n") # rubocop:disable Metrics/LineLength
         end
       end
     end
@@ -145,7 +145,7 @@ RSpec.shared_examples 'Commands' do |cli|
 
       it 'with unknown param' do
         error = capture_error { cli.call(arguments: %w[new bookshelf --unknown 1234]) }
-        expect(error).to eq("Error: \"new\" was called with arguments \"bookshelf --unknown 1234\"\n") # rubocop:disable Metrics/LineLength
+        expect(error).to eq("Error: \"rspec new\" was called with arguments \"bookshelf --unknown 1234\"\n") # rubocop:disable Metrics/LineLength
       end
 
       it 'no required' do


### PR DESCRIPTION
In this PR I removed the generation of ProgName from Banner and Parser. We used it to print error messages from this classes. Instead, I pass a one time generated progname. 

And now it behaves as it was initially planned https://github.com/dry-rb/dry-cli/blob/master/lib/dry/cli/command.rb#L177-L179.

```ruby
      # $ foo generate action
      #   ERROR: "foo generate action" was called with no arguments
      #   Usage: "foo generate action APP ACTION"
```

And made `ERROR` tag consistent in a project.