### PR TITLE
Ability to register instances in Registry

### DIFF
--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -50,11 +50,11 @@ module Dry
         # @api private
         attr_reader :options
 
-        # @since 0.6.x
+        # @since x.x.x
         # @api private
         attr_reader :subcommands
 
-        # @since 0.6.x
+        # @since x.x.x
         # @api private
         attr_writer :subcommands
       end
@@ -351,7 +351,7 @@ module Dry
         arguments.reject(&:required?)
       end
 
-      # @since 0.6.x
+      # @since x.x.x
       # @api private
       def self.subcommands
         subcommands

--- a/lib/dry/cli/command_registry.rb
+++ b/lib/dry/cli/command_registry.rb
@@ -26,7 +26,10 @@ module Dry
           end
 
           node.aliases!(aliases)
-          node.leaf!(command) if command
+          if command
+            node.leaf!(command)
+            node.subcommands!(command)
+          end
 
           nil
         end
@@ -127,7 +130,13 @@ module Dry
         # @api private
         def leaf!(command)
           @command = command
-          command.subcommands = children
+        end
+
+        # @since x.x.x
+        # @api private
+        def subcommands!(command)
+          command_class = command.is_a?(Class) ? command : command.class
+          command_class.subcommands = children
         end
 
         # @since 0.1.0
@@ -150,7 +159,7 @@ module Dry
           !command.nil?
         end
 
-        # @since 0.6.x
+        # @since x.x.x
         # @api private
         def children?
           children.any?

--- a/spec/support/fixtures/shared_commands.rb
+++ b/spec/support/fixtures/shared_commands.rb
@@ -437,6 +437,18 @@ module Commands
       end
     end
   end
+
+  class InitializedCommand < Dry::CLI::Command
+    attr_reader :prop
+
+    def initialize(prop:)
+      @prop = prop
+    end
+
+    def call(**_params)
+      puts "The value of prop is #{prop}"
+    end
+  end
 end
 
 module Webpack

--- a/spec/support/fixtures/with_block.rb
+++ b/spec/support/fixtures/with_block.rb
@@ -18,6 +18,7 @@ WithBlock = Dry::CLI.new do |cli|
   cli.register 'hello',       Commands::Hello
   cli.register 'greeting',    Commands::Greeting
   cli.register 'sub command', Commands::Sub::Command
+  cli.register 'with-initializer', Commands::InitializedCommand.new(prop: 'prop_val')
   cli.register 'root-command', Commands::RootCommand do |prefix|
     prefix.register 'sub-command', Commands::RootCommands::SubCommand
   end

--- a/spec/support/fixtures/with_registry.rb
+++ b/spec/support/fixtures/with_registry.rb
@@ -48,6 +48,7 @@ module Foo
       register 'hello',       ::Commands::Hello
       register 'greeting',    ::Commands::Greeting
       register 'sub command', ::Commands::Sub::Command
+      register 'with-initializer', ::Commands::InitializedCommand.new(prop: 'prop_val')
       register 'root-command', ::Commands::RootCommand
       register 'root-command sub-command', ::Commands::RootCommands::SubCommand
 

--- a/spec/support/fixtures/with_zero_arity_block.rb
+++ b/spec/support/fixtures/with_zero_arity_block.rb
@@ -18,6 +18,7 @@ WithZeroArityBlock = Dry.CLI do
   register 'hello',       Commands::Hello
   register 'greeting',    Commands::Greeting
   register 'sub command', Commands::Sub::Command
+  register 'with-initializer', Commands::InitializedCommand.new(prop: 'prop_val')
   register 'root-command', Commands::RootCommand
   register 'root-command' do
     register 'sub-command', Commands::RootCommands::SubCommand

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -289,5 +289,12 @@ RSpec.shared_examples 'Commands' do |cli|
       end
     end
   end
+
+  context 'works with instances of commands' do
+    it 'executes instance' do
+      output = capture_output { cli.call(arguments: %w[with-initializer]) }
+      expect(output).to eq("The value of prop is prop_val\n")
+    end
+  end
 end
 # rubocop:enable Metrics/LineLength

--- a/spec/support/shared_examples/rendering.rb
+++ b/spec/support/shared_examples/rendering.rb
@@ -26,6 +26,7 @@ RSpec.shared_examples 'Rendering' do |cli|
         #{cmd} sub [SUBCOMMAND]
         #{cmd} variadic [SUBCOMMAND]
         #{cmd} version                                                 # Print Foo version
+        #{cmd} with-initializer
     DESC
 
     expect(error).to eq(expected)
@@ -85,6 +86,7 @@ RSpec.shared_examples 'Rendering' do |cli|
         #{cmd} sub [SUBCOMMAND]
         #{cmd} variadic [SUBCOMMAND]
         #{cmd} version                                                 # Print Foo version
+        #{cmd} with-initializer
     DESC
 
     expect(error).to eq(expected)
@@ -112,6 +114,7 @@ RSpec.shared_examples 'Rendering' do |cli|
         #{cmd} sub [SUBCOMMAND]
         #{cmd} variadic [SUBCOMMAND]
         #{cmd} version                                                 # Print Foo version
+        #{cmd} with-initializer
     DESC
 
     expect(error).to eq(expected)


### PR DESCRIPTION
Ability to push instances of commands to registry.
Initially, all commands had `command_name` attribute inside constructor, so that you had some problems with initialization of command objects. 
I removed it couple of minor versions ago and since then `dry-cli` freed `#initializer` to everybody.

Though, it was quite useless, since `dry-cli` instanciate commands inside itself, and developer doesn't have ability to configure command even if they can implement their own initializer method without calling super.
Now you can write something like that:

```ruby
require 'sequel'
DB = Sequel.sqlite

Dry.CLI do
  register 'version', Version # <= subclass of Dry::CLI::Command, not instance
  register 'run', Runner.new(db: DB)
end
```

