### PR TITLE
Fix ruby 2.7 keyword args warning

### DIFF
--- a/lib/hanami/cli.rb
+++ b/lib/hanami/cli.rb
@@ -56,7 +56,7 @@ module Hanami
         command, args = parse(result, out)
 
         result.before_callbacks.run(command, args)
-        command.call(args)
+        command.call(**args)
         result.after_callbacks.run(command, args)
       else
         usage(result, out)


### PR DESCRIPTION
Before this change, any CLI users would see a warning like this every time a command was invoked:

```
/Users/tim/Source/hanami/cli/lib/hanami/cli.rb:59: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/tim/Source/my-app/lib/hanami/cli/application/commands/db/version.rb:17: warning: The called method `call' is defined here
```

For a CLI tool, having this extra output noise is really undesirable.

I know we'll eventually be moving hanami/hanami to use dry-cli under the hood, but this fix here in the meantime will help anyone currently using the hanami unstable branches.