### PR TITLE
103 Safely rescue interrupts

### DIFF
--- a/spec/integration/signal_trap_spec.rb
+++ b/spec/integration/signal_trap_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe "SignalException handler" do
+  it "returns correct statuscode" do
+    pid1, pid2, pid15 = Array.new(3).map { Process.spawn("foo generate app SomeAppName") }
+    sleep 0.5 # time to start app
+
+    Process.kill("HUP", pid1)
+    Process.kill("INT", pid2)
+    Process.kill("TERM", pid15)
+
+    _, status1 = Process.wait2(pid1)
+    _, status2 = Process.wait2(pid2)
+    _, status15 = Process.wait2(pid15)
+
+    expect(status1.exitstatus).to eq(129)
+    expect(status2.exitstatus).to eq(130)
+    expect(status15.exitstatus).to eq(143)
+  end
+end

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/LineLength
-$LOAD_PATH.unshift __dir__ + "/../../lib"
+# rubocop:disable Layout/LineLength
+$LOAD_PATH.unshift __dir__ + "/../../../lib"
 require "dry/cli"
 
 module Foo
@@ -200,7 +200,9 @@ module Foo
             "api --application-base-url=/api/v1 # Generate `api` app and mount at `/api/v1`"
           ]
 
-          def call(*); end
+          def call(*)
+            loop { sleep(0.1) }
+          end
         end
 
         class Mailer < Dry::CLI::Command
@@ -575,7 +577,7 @@ module Callbacks
     end
   end
 end
-# rubocop:enable Metrics/LineLength
+# rubocop:enable Layout/LineLength
 
 Foo::CLI::Commands.before("callbacks", Callbacks::BeforeClass)
 Foo::CLI::Commands.after("callbacks",  Callbacks::AfterClass)

--- a/spec/unit/dry/cli/cli_spec.rb
+++ b/spec/unit/dry/cli/cli_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "CLI" do
       include_examples "Commands", WithZeroArityBlock
       include_examples "Rendering", WithZeroArityBlock
       include_examples "Subcommands", WithZeroArityBlock
-      include_examples "Inherited commands", WithBlock
+      include_examples "Inherited commands", WithZeroArityBlock
       include_examples "Third-party gems", WithZeroArityBlock
     end
   end


### PR DESCRIPTION
Resolves #103 
 

> If a ruby program is interrupted by Ctrl^C or sent a SIGINT signal, the Interrupt exception is raised, causing an ugly backtrace to be printed. Ideally, Dry::CLI should rescue Interrupt and exit with a status of 130 (see: https://tldp.org/LDP/abs/html/exitcodes.html).

Now works as expected