### PR TITLE
Preparing 0.7.0 release

### DIFF
--- a/changelog.yml
+++ b/changelog.yml
@@ -1,52 +1,70 @@
 ---
+- version: 0.7.0
+  date: '2020-05-08'
+  added:
+    - "Inheritable attributes for subclasses of commands (@IvanShamatov)"
+    - "Ability to register instances, not only classes as Commands (@IvanShamatov)"
+    - "Add support for subcommands with a parent command (@unrooty)"
+  changed:
+    - "Extracted Dry::CLI::Utils::Files into dry-files (@jodosha)"
+    - "Drop 2.3 ruby support (@IvanShamatov)"
+    - "[Internal] Changelog, issue templates (@solnic)"
+    - "Documentation updates (@davydovanton)"
+    - "Remove concurrent-ruby as runtime dependency (@jodosha)"
+    - "[Internal] Banner and Parses refactoring (@IvanShamatov)"
+  fixed:
+    - "Safely rescue pipe exception, when you CLI app is producing output for piped CLI app (IvanShamatov)"
+    - "Safely rescue keyboard interrupts (@IvanShamatov)"
+    - "[Internal] Don't run specs twice (@jodosha)"
+    - "Update inline call with keyward arguments (@flash-gordon)"
 - version: 0.6.0
   date: '2020-03-06'
   added:
-    - "[Ivan Shamatov] Ability to pass command along with registry (for a singular command case)"
-    - "[Nikita Shilnikov] [Internal] Backported ability to run gem's CI against ruby 2.3"
-    - "[Ivan Shamatov] Inline syntax for commands"
-    - "[Ivan Shamatov] Introduced stderr to any diagnostic output"
+    - "Ability to pass command along with registry (for a singular command case) (@IvanShamatov)"
+    - "[Internal] Backported ability to run gem's CI against ruby 2.3 (@flash-gordon)"
+    - "Inline syntax for commands (@IvanShamatov)"
+    - "Introduced stderr to any diagnostic output (@IvanShamatov)"
   fixed:
-    - "[John Ledbetter & Luca Guidi] Fix ruby 2.7 warnings"
-    - "[Ivan Shamatov] Fix banner, when option is a type of Array"
+    - "[John Ledbetter & Luca Guidi] Fix ruby 2.7 warnings (@jodosha)"
+    - "Fix banner, when option is a type of Array (@IvanShamatov)"
 - version: 0.5.1
   date: '2020-01-23'
   added:
-    - "[Ivan Shamatov] Anonymous Registry sintax"
-    - "[Ivan Shamatov] [Internal] Specs refactored, more unit specs added"
-    - "[Luca Guidi] [Internal] removed `dry-inflector` as runtime dependency"
-    - "[Ivan Shamatov] [Internal] Refactored Command class (command_name property removed)"
-    - "[Piotr Solnica, Luca Guidi, Nikita Shilnikov & Christian Georgii] [Internal] Adapt gem to dry-rb style"
+    - "Anonymous Registry sintax (@IvanShamatov)"
+    - "[Internal] Specs refactored, more unit specs added (@IvanShamatov)"
+    - "[Internal] removed `dry-inflector` as runtime dependency (@jodosha)"
+    - "[Internal] Refactored Command class (command_name property removed) (@IvanShamatov)"
+    - "[Internal] Adapt gem to dry-rb style (@jodosha, @flash-gordon, @solnic, @cgeorgii)"
   fixed:
-    - "[Piotr Solnica] Added missing 'set' require"
+    - "Added missing 'set' require (@solnic)"
 - version: 0.5.0
   date: '2019-12-21'
   added:
-  - "[Ivan Shamatov, Piotr Solnica, Luca Guidi] [Internal] removed runtime and development
-    dependency against `hanami-utils`"
+  - "[Internal] removed runtime and development
+    dependency against `hanami-utils` (@jodosha, @IvanShamatov, @solnic)"
 - version: 0.4.0
   date: '2019-12-10'
   added:
-  - "[Ivan Shamatov, Piotr Solnica, Luca Guidi] `hanami-cli` => `dry-cli`"
+  - "`hanami-cli` => `dry-cli` (@jodosha, @IvanShamatov, @solnic)"
 - version: 0.3.1
   date: '2019-01-18'
   added:
-  - "[Luca Guidi] Official support for Ruby: MRI 2.6"
-  - "[Luca Guidi] Support `bundler` 2.0+"
+  - "Official support for Ruby: MRI 2.6 (@jodosha)"
+  - "Support `bundler` 2.0+ (@jodosha)"
 - version: 0.3.0
   date: '2018-10-24'
 - version: 0.3.0.beta1
   date: '2018-08-08'
   added:
-  - "[Anton Davydov & Alfonso Uceda] Introduce array type for arguments (`foo exec
-    test spec/bookshelf/entities spec/bookshelf/repositories`)"
-  - "[Anton Davydov & Alfonso Uceda] Introduce array type for options (`foo generate
-    config --apps=web,api`)"
-  - "[Alfonso Uceda] Introduce variadic arguments (`foo run ruby:latest -- ruby -v`)"
-  - "[Luca Guidi] Official support for JRuby 9.2.0.0"
+  - "Introduce array type for arguments (`foo exec
+    test spec/bookshelf/entities spec/bookshelf/repositories`) (@davydovanton, @AlfonsoUceda)"
+  - "Introduce array type for options (`foo generate
+    config --apps=web,api`) (@davydovanton, @AlfonsoUceda)"
+  - "Introduce variadic arguments (`foo run ruby:latest -- ruby -v`)"
+  - "Official support for JRuby 9.2.0.0 (@jodosha, @AlfonsoUceda)"
   fixed:
-  - '[Anton Davydov] Print informative message when unknown or wrong option is passed
-    (`"test" was called with arguments "--framework=unknown"`)'
+  - 'Print informative message when unknown or wrong option is passed
+    (`"test" was called with arguments "--framework=unknown"`) (@davydovanton)'
 - version: 0.2.0
   date: '2018-04-11'
 - version: 0.2.0.rc2
@@ -56,22 +74,21 @@
 - version: 0.2.0.beta2
   date: '2018-03-23'
   added:
-  - "[Anton Davydov & Luca Guidi] Support objects as callbacks"
+  - "Support objects as callbacks (@jodosha, @davydovanton)"
   fixed:
-  - "[Anton Davydov & Luca Guidi] Ensure callbacks' context of execution (aka `self`)
-    to be the command that is being executed"
+  - "Ensure callbacks' context of execution (aka `self`) to be the command that is being executed (@jodosha, @davydovanton)"
 - version: 0.2.0.beta1
   date: '2018-02-28'
   added:
-  - "[Anton Davydov] Register `before`/`after` callbacks for commands"
+  - "Register `before`/`after` callbacks for commands (@davydovanton)"
 - version: 0.1.1
   date: '2018-02-27'
   added:
-  - "[Luca Guidi] Official support for Ruby: MRI 2.5"
+  - "Official support for Ruby: MRI 2.5 (@jodosha)"
   fixed:
-  - "[Alfonso Uceda] Ensure default values for arguments to be sent to commands"
-  - "[Alfonso Uceda] Ensure to fail when a missing required argument isn't provider,
-    but an option is provided instead"
+  - "Ensure default values for arguments to be sent to commands (@AlfonsoUceda)"
+  - "Ensure to fail when a missing required argument isn't provider,
+    but an option is provided instead (@AlfonsoUceda)"
 - version: 0.1.0
   date: '2017-10-25'
 - version: 0.1.0.rc1
@@ -81,17 +98,17 @@
 - version: 0.1.0.beta2
   date: '2017-10-03'
   added:
-  - " [Alfonso Uceda] Allow default value for arguments"
+  - "Allow default value for arguments (@AlfonsoUceda)"
 - version: 0.1.0.beta1
   date: '2017-08-11'
   added:
-  - " [Alfonso Uceda, Luca Guidi] Commands banner and usage"
-  - " [Alfonso Uceda] Added support for subcommands"
-  - "[Alfonso Uceda] Validations for arguments and options"
-  - "[Alfonso Uceda] Commands arguments and options"
-  - "[Alfonso Uceda] Commands description"
-  - "[Alfonso Uceda, Oana Sipos] Commands aliases"
-  - "[Luca Guidi] Exit on unknown command"
-  - "[Luca Guidi, Alfonso Uceda, Oana Sipos] Command lookup"
-  - "[Luca Guidi, Tim Riley] Trie based registry to register commands and allow third-parties
-    to override/add commands"
+  - "Commands banner and usage (@jodosha, @AlfonsoUceda)"
+  - "Added support for subcommands (@AlfonsoUceda)"
+  - "Validations for arguments and options (@AlfonsoUceda)"
+  - "Commands arguments and options (@AlfonsoUceda)"
+  - "Commands description (@AlfonsoUceda)"
+  - "Commands aliases (@AlfonsoUceda, @oana-sipos)"
+  - "Exit on unknown command (@jodosha)"
+  - "Command lookup (@AlfonsoUceda, @oana-sipos)"
+  - "Trie based registry to register commands and allow third-parties
+    to override/add commands (@jodosha, @timriley)"

--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -43,11 +43,11 @@ module Dry
         # @api private
         attr_reader :options
 
-        # @since x.x.x
+        # @since 0.7.0
         # @api private
         attr_reader :subcommands
 
-        # @since x.x.x
+        # @since 0.7.0
         # @api private
         attr_writer :subcommands
       end
@@ -344,7 +344,7 @@ module Dry
         arguments.reject(&:required?)
       end
 
-      # @since x.x.x
+      # @since 0.7.0
       # @api private
       def self.subcommands
         subcommands

--- a/lib/dry/cli/command_registry.rb
+++ b/lib/dry/cli/command_registry.rb
@@ -132,7 +132,7 @@ module Dry
           @command = command
         end
 
-        # @since x.x.x
+        # @since 0.7.0
         # @api private
         def subcommands!(command)
           command_class = command.is_a?(Class) ? command : command.class
@@ -159,7 +159,7 @@ module Dry
           !command.nil?
         end
 
-        # @since x.x.x
+        # @since 0.7.0
         # @api private
         def children?
           children.any?

--- a/lib/dry/cli/version.rb
+++ b/lib/dry/cli/version.rb
@@ -3,6 +3,6 @@
 module Dry
   class CLI
     # @since 0.1.0
-    VERSION = "0.6.0"
+    VERSION = "0.7.0"
   end
 end

--- a/spec/unit/dry/cli/version_spec.rb
+++ b/spec/unit/dry/cli/version_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe "Dry::CLI::VERSION" do
   it "exposes version" do
-    expect(Dry::CLI::VERSION).to eq("0.6.0")
+    expect(Dry::CLI::VERSION).to eq("0.7.0")
   end
 end


### PR DESCRIPTION
Changelog update

- version: 0.7.0
  date: '2020-05-08'
  added:
    - "[Ivan Shamatov] Inheritable attributes for subclasses of commands"
    - "[Ivan Shamatov] Ability to register instances, not only classes as commands"
    - "[Vladislav Volkov] Add support for subcommands with a parent command"
  changed:
    - "[Luca Guidi] Extracted Dry::CLI::Utils::Files into dry-files"
    - "[Ivan Shamatov] Drop 2.3 ruby support"
    - "[Piotr Solnica] [Internal] Changelog, issue templates"
    - "[Anton Davydov] Documentation updates"
    - "[Luca Guidi] Remove concurrent-ruby as runtime dependency"
    - "[Ivan Shamatov] [Internal] Banner and Parses refactoring"
  fixed:
    - "[Ivan Shamatov] Safely rescue pipe exception, when you CLI app is producing output for piped CLI app"
    - "[Ivan Shamatov] Safely rescue keyboard interrupts"
    - "[Luca Guidi] [Internal] Don't run specs twice"
    - "[Nikita Shilnikov] Update inline call with keyward arguments"