### PR TITLE
Fix documentation for Command.option

### DIFF
--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -213,7 +213,7 @@ module Dry
       #   require "dry/cli"
       #
       #   class Console < Dry::CLI::Command
-      #     param :engine
+      #     option :engine
       #
       #     def call(engine: nil, **)
       #       puts "starting console (engine: #{engine || :irb})"
@@ -230,7 +230,7 @@ module Dry
       #   require "dry/cli"
       #
       #   class Console < Dry::CLI::Command
-      #     param :engine, values: %w(irb pry ripl)
+      #     option :engine, values: %w(irb pry ripl)
       #
       #     def call(engine: nil, **)
       #       puts "starting console (engine: #{engine || :irb})"
@@ -250,7 +250,7 @@ module Dry
       #   require "dry/cli"
       #
       #   class Console < Dry::CLI::Command
-      #     param :engine, desc: "Force a console engine"
+      #     option :engine, desc: "Force a console engine"
       #
       #     def call(engine: nil, **)
       #       # ...
@@ -268,7 +268,7 @@ module Dry
       #   require "dry/cli"
       #
       #   class Server < Dry::CLI::Command
-      #     param :code_reloading, type: :boolean, default: true
+      #     option :code_reloading, type: :boolean, default: true
       #
       #     def call(code_reloading:, **)
       #       puts "staring server (code reloading: #{code_reloading})"
@@ -291,7 +291,7 @@ module Dry
       #   require "dry/cli"
       #
       #   class Server < Dry::CLI::Command
-      #     param :port, aliases: ["-p"]
+      #     option :port, aliases: ["-p"]
       #
       #     def call(options)
       #       puts "staring server (port: #{options.fetch(:port, 2300)})"


### PR DESCRIPTION
Examples were using param instead of option.