### PR TITLE
Add :flag option type, for boolean options without the [no-] prefix

### DIFF
--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -109,6 +109,8 @@ module Dry
           name = Inflector.dasherize(option.name)
           name = if option.boolean?
                    "[no-]#{name}"
+                 elsif option.flag?
+                   name
                  elsif option.array?
                    "#{name}=VALUE1,VALUE2,.."
                  else

--- a/lib/dry/cli/option.rb
+++ b/lib/dry/cli/option.rb
@@ -59,6 +59,11 @@ module Dry
         type == :boolean
       end
 
+      # @api private
+      def flag?
+        type == :flag
+      end
+
       # @since 0.3.0
       # @api private
       def array?
@@ -92,6 +97,8 @@ module Dry
 
         if boolean?
           parser_options << "--[no-]#{dasherized_name}"
+        elsif flag?
+          parser_options << "--#{dasherized_name}"
         else
           parser_options << "--#{dasherized_name}=#{name}"
           parser_options << "--#{dasherized_name} #{name}"
@@ -112,7 +119,7 @@ module Dry
           .compact
           .uniq
           .map { |name| name.size == 1 ? "-#{name}" : "--#{name}" }
-          .map { |name| boolean? ? name : "#{name} VALUE" }
+          .map { |name| boolean? || flag? ? name : "#{name} VALUE" }
       end
     end
 

--- a/spec/support/fixtures/shared_commands.rb
+++ b/spec/support/fixtures/shared_commands.rb
@@ -299,6 +299,7 @@ module Commands
     option :daemonize,      desc: "Daemonize the server"
     option :pid,            desc: "Path to write a pid file after daemonize"
     option :code_reloading, desc: "Code reloading", type: :boolean, default: true
+    option :quiet,          desc: "Suppress output to stdout", type: :flag
     option :deps,           desc: "List of extra dependencies", type: :array, default: %w[dep1 dep2]
 
     example [

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -73,6 +73,14 @@ RSpec.shared_examples "Commands" do |cli|
       expect(output).to eq("server - {:code_reloading=>false, :deps=>[\"dep1\", \"dep2\"]}\n")
     end
 
+    it "with flag param" do
+      output = capture_output { cli.call(arguments: ["server"]) }
+      expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"]}\n")
+
+      output = capture_output { cli.call(arguments: %w[server --quiet]) }
+      expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :quiet=>true}\n")
+    end
+
     context "with array param" do
       it "allows to omit optional array argument" do
         output = capture_output { cli.call(arguments: %w[exec test]) }
@@ -123,6 +131,7 @@ RSpec.shared_examples "Commands" do |cli|
           --daemonize=VALUE                 # Daemonize the server
           --pid=VALUE                       # Path to write a pid file after daemonize
           --[no-]code-reloading             # Code reloading, default: true
+          --quiet                           # Suppress output to stdout
           --deps=VALUE1,VALUE2,..           # List of extra dependencies, default: ["dep1", "dep2"]
           --help, -h                        # Print this help
 


### PR DESCRIPTION
Acts like :boolean, but doesn't imply `--[no-]` prefix

#42 