### PR TITLE
Fix wrong example for subcommands

### DIFF
--- a/docsite/source/subcommands.html.md
+++ b/docsite/source/subcommands.html.md
@@ -34,5 +34,5 @@ Dry::CLI.new(Foo::CLI::Commands).call
 ```sh
 $ foo generate
 Commands:
-  foo generate config           # Generate configuration
+  foo generate configuration           # Generate configuration
 ```


### PR DESCRIPTION
It doesn't work with `foo generate config` after setting up `Foo::CLI::Commands.register "generate configuration"`
The command should have the same name.

I.e. it's better to change 
```ruby
Foo::CLI::Commands.register "generate configuration"
```
for
```ruby
Foo::CLI::Commands.register "generate config"
```

or `foo generate config` to `foo generate configuration`. I decided to go with second option