### PR TITLE
Add `aliases` to options

### DIFF
--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -98,7 +98,7 @@ module Foo
         class Configuration < Dry::CLI::Command
           desc "Generate configuration"
 
-          option :apps, type: :array, default: [], desc: "Generate configuration for specific apps"
+          option :apps, type: :array, default: [], aliases: ["-a"], desc: "Generate configuration for specific apps"
 
           def call(apps:, **)
             puts "generated configuration for apps: #{apps.inspect}"

--- a/docsite/source/options.html.md
+++ b/docsite/source/options.html.md
@@ -20,7 +20,7 @@ module Foo
       extend Dry::CLI::Registry
 
       class Request < Dry::CLI::Command
-        option :mode, default: "http", values: %w[http http2], desc: "The request mode"
+        option :mode, default: "http", values: %w[http http2], aliases: ["-m"], desc: "The request mode"
 
         def call(**options)
           puts "Performing a request (mode: #{options.fetch(:mode)})"
@@ -42,6 +42,11 @@ Performing a request (mode: http)
 
 ```sh
 $ foo request --mode=http2
+Performing a request (mode: http2)
+```
+
+```sh
+$ foo request --m=http2
 Performing a request (mode: http2)
 ```
 


### PR DESCRIPTION
They were missing from the docs.