### PR TITLE
Fix CI for Ruby 3.3

### DIFF
--- a/spec/unit/dry/cli/registry_spec.rb
+++ b/spec/unit/dry/cli/registry_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe Dry::CLI::Registry do
 
     context "when class is given" do
       it "raises error when #initialize arity is not equal to 0" do
-        callback = Struct
+        callback = Class.new do
+          def initialize(foo); end
+        end
 
         expect do
           Bar::CLI::Commands.before("alpha", callback)
@@ -64,7 +66,9 @@ RSpec.describe Dry::CLI::Registry do
 
     context "when class is given" do
       it "raises error when #initialize arity is not equal to 0" do
-        callback = Struct
+        callback = Class.new do
+          def initialize(foo); end
+        end
 
         expect do
           Bar::CLI::Commands.after("alpha", callback)


### PR DESCRIPTION
This has been broken for a while now. `Struct.new` (with no args) used to raise an error in Ruby 3.2 and earlier, but in 3.3 it's allowed. So in this PR we make a new class that actually requires an arg so the test raises the expected error