### PR TITLE
Keyword arguments for a command aren't passed correctly to commands that use callbacks

### DIFF
--- a/lib/dry/cli.rb
+++ b/lib/dry/cli.rb
@@ -112,9 +112,9 @@ module Dry
 
       command, args = parse(result.command, result.arguments, result.names)
 
-      result.before_callbacks.run(command, args)
+      result.before_callbacks.run(command, **args)
       command.call(**args)
-      result.after_callbacks.run(command, args)
+      result.after_callbacks.run(command, **args)
     end
 
     # Parse arguments for a command.

--- a/lib/dry/cli/command_registry.rb
+++ b/lib/dry/cli/command_registry.rb
@@ -243,9 +243,9 @@ module Dry
 
         # @since 0.4.0
         # @api private
-        def run(context, *args)
+        def run(context, **args)
           chain.each do |callback|
-            context.instance_exec(*args, &callback)
+            context.instance_exec(**args, &callback)
           end
         end
       end

--- a/spec/integration/third_party_gems_spec.rb
+++ b/spec/integration/third_party_gems_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe "Third-party gems" do
     expected = <<~OUTPUT
       before command callback Foo::Webpack::CLI::CallbacksCommand {:url=>"https://hanamirb.test", :dir=>"."}
       before callback (class), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
+      before callback (class), kwarg(s): url: https://hanamirb.test, dir: .
       before callback (object), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
       dir: ., url: "https://hanamirb.test"
       after command callback Foo::Webpack::CLI::CallbacksCommand {:url=>"https://hanamirb.test", :dir=>"."}
       after callback (class), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
+      after callback (class), kwarg(s): url: https://hanamirb.test, dir: .
       after callback (object), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
     OUTPUT
     expect(output).to eq(expected)

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -541,6 +541,12 @@ module Callbacks
     end
   end
 
+  class BeforeKwargsClass
+    def call(url:, dir:, **)
+      puts "before callback (class), kwarg(s): url: #{url}, dir: #{dir}"
+    end
+  end
+
   class AfterClass
     def call(args)
       puts "after callback (class), #{count(args)} arg(s): #{args.inspect}"
@@ -550,6 +556,12 @@ module Callbacks
 
     def count(args)
       args.count
+    end
+  end
+
+  class AfterKwargsClass
+    def call(url:, dir:, **)
+      puts "after callback (class), kwarg(s): url: #{url}, dir: #{dir}"
     end
   end
 
@@ -580,7 +592,9 @@ end
 # rubocop:enable Layout/LineLength
 
 Foo::CLI::Commands.before("callbacks", Callbacks::BeforeClass)
+Foo::CLI::Commands.before("callbacks",  Callbacks::BeforeKwargsClass)
 Foo::CLI::Commands.after("callbacks",  Callbacks::AfterClass)
+Foo::CLI::Commands.after("callbacks",  Callbacks::AfterKwargsClass)
 Foo::CLI::Commands.before("callbacks", Callbacks::Before.new)
 Foo::CLI::Commands.after("callbacks",  Callbacks::After.new)
 


### PR DESCRIPTION
Resolve #113 

It seems that the solution is backward compatible, so implementations like this [one](https://github.com/hanami/rspec/blob/f7f19dcebe4152f17676313e649ba6556365c488/lib/hanami/rspec/commands.rb#L99) will continue to work.