### PR TITLE
Fix arguments with `values` allowing any value

### DIFF
--- a/lib/dry/cli/errors.rb
+++ b/lib/dry/cli/errors.rb
@@ -9,6 +9,10 @@ module Dry
     class Error < StandardError
     end
 
+    # @since 1.3.0
+    class UnknownValueError < Error
+    end
+
     # @since 0.2.1
     class UnknownCommandError < Error
       # @since 0.2.1

--- a/lib/dry/cli/option.rb
+++ b/lib/dry/cli/option.rb
@@ -121,6 +121,19 @@ module Dry
           .map { |name| name.size == 1 ? "-#{name}" : "--#{name}" }
           .map { |name| boolean? || flag? ? name : "#{name} VALUE" }
       end
+
+      # @since 1.3.0
+      # @api private
+      def valid_value?(value)
+        available_values = values
+        return true if available_values.nil?
+
+        if array?
+          (value - available_values).empty?
+        else
+          available_values.map(&:to_s).include?(value.to_s)
+        end
+      end
     end
 
     # Command line argument

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -91,7 +91,7 @@ module Foo
         class Rollback < Dry::CLI::Command
           desc "Rollback the database"
 
-          argument :steps, desc: "Number of versions to rollback", default: 1
+          argument :steps, desc: "Number of versions to rollback", default: 1, values: [1, 2, 3]
 
           def call(steps:, **)
             puts steps

--- a/spec/support/fixtures/shared_commands.rb
+++ b/spec/support/fixtures/shared_commands.rb
@@ -82,7 +82,7 @@ module Commands
     class Rollback < Dry::CLI::Command
       desc "Rollback the database"
 
-      argument :steps, desc: "Number of versions to rollback", default: 1
+      argument :steps, desc: "Number of versions to rollback", default: 1, values: [1, 2, 3]
 
       def call(steps:, **)
         puts steps

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -106,6 +106,13 @@ RSpec.shared_examples "Commands" do |cli|
           expect(error).to eq("ERROR: \"rspec console\" was called with arguments \"--engine=unknown\"\n")
         end
       end
+
+      context "with an unknown argument" do
+        it "prints error" do
+          error = capture_error { cli.call(arguments: %w[db rollback 4]) }
+          expect(error).to eq("ERROR: \"rspec db rollback\" was called with arguments \"4\"\n")
+        end
+      end
     end
 
     it "with help param" do


### PR DESCRIPTION
Resolve #126

As reported by the issue above, it's possible to define possible values for arguments, but we don't validate if the received value can be used. With this PR the behavior will be the same of options:


https://github.com/user-attachments/assets/c2ac885c-4c90-4dcc-9e4d-fb168d247555

