### PR TITLE
Prevent duplicate arguments/options

### DIFF
--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -195,7 +195,12 @@ module Dry
       #   #   Options:
       #   #     --help, -h          # Print this help
       def self.argument(name, options = {})
-        @arguments << Argument.new(name, options)
+        new_arg = Argument.new(name, options)
+
+        duplicate_index = @arguments.find_index { _1.name == new_arg.name }
+        @arguments.delete_at(duplicate_index) unless duplicate_index.nil?
+
+        @arguments << new_arg
       end
 
       # Command line option (aka optional argument)
@@ -309,7 +314,12 @@ module Dry
       #   # Options:
       #   #   --port=VALUE, -p VALUE
       def self.option(name, options = {})
-        @options << Option.new(name, options)
+        new_op = Option.new(name, options)
+
+        duplicate_index = @options.find_index { _1.name == new_op.name }
+        @options.delete_at(duplicate_index) unless duplicate_index.nil?
+
+        @options << new_op
       end
 
       # @since 0.1.0

--- a/spec/unit/dry/cli/command_spec.rb
+++ b/spec/unit/dry/cli/command_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe "Command" do
+  describe "option definition" do
+    class CommandWithDuplicateOpts < Dry::CLI::Command
+      option :engine, desc: "1", values: %w[irb pry ripl]
+      option :engine, desc: "2", values: %w[test1 test2 test3]
+    end
+
+    it "prevents duplicate options" do
+      opts = CommandWithDuplicateOpts.options
+      expect(opts.size).to eq(1)
+      op = opts.first
+      expect(op.name).to eq(:engine)
+      expect(op.desc).to eq("2: (test1/test2/test3)")
+    end
+  end
+
+  describe "argument definition" do
+    class CommandWithDuplicateArgs < Dry::CLI::Command
+      argument :version, desc: "1"
+      argument :version, desc: "2"
+    end
+
+    it "prevents duplicate arguments" do
+      opts = CommandWithDuplicateArgs.arguments
+      expect(opts.size).to eq(1)
+      op = opts.first
+      expect(op.name).to eq(:version)
+      expect(op.desc).to eq("2")
+    end
+  end
+end


### PR DESCRIPTION
Resolve #139 

This PR resolves the issue above by always considering the last defined argument/option (i.e. the last override the previous definition).