### PR TITLE
Always display array arguments in the end when printing command usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Fixed
 
+- Optional arguments were incorrectly displayed at the end of usage message (@gustavothecoder in #145)
+
 ### Security
 
 [Unreleased]: https://github.com/dry-rb/dry-cli/compare/v1.4.1...main

--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -85,7 +85,7 @@ module Dry
       def self.arguments(command)
         args = command.arguments_sorted_by_usage_order
         args.map! do |a|
-          name = a.required? ? a.name.to_s : "[#{a.name}]"
+          name = a.required? ? "#{a.name}" : "[#{a.name}]"
           name.upcase!
         end
 

--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -83,14 +83,13 @@ module Dry
       # @since 0.1.0
       # @api private
       def self.arguments(command)
-        required_arguments = command.required_arguments
-        optional_arguments = command.optional_arguments
+        args = command.arguments_sorted_by_usage_order
+        args.map! do |a|
+          name = a.required? ? a.name.to_s : "[#{a.name}]"
+          name.upcase!
+        end
 
-        required = required_arguments.map { |arg| arg.name.upcase }.join(" ") if required_arguments.any?
-        optional = optional_arguments.map { |arg| "[#{arg.name.upcase}]" }.join(" ") if optional_arguments.any?
-        result = [required, optional].compact
-
-        " #{result.join(" ")}" unless result.empty?
+        " #{args.join(" ")}" unless args.empty?
       end
 
       # @since 0.1.0

--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -85,7 +85,8 @@ module Dry
       def self.arguments(command)
         args = command.arguments_sorted_by_usage_order
         args.map! do |a|
-          name = a.required? ? "#{a.name}" : "[#{a.name}]"
+          # a.to_s raises deprecation warning that it will result in a frozen string in the future
+          name = a.required? ? "#{a.name}" : "[#{a.name}]" # rubocop:disable Style/RedundantInterpolation
           name.upcase!
         end
 

--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -350,6 +350,31 @@ module Dry
         arguments.reject(&:required?)
       end
 
+      # @since 1.3.0
+      # @api private
+      # rubocop:disable Metrics/PerceivedComplexity
+      def self.arguments_sorted_by_usage_order
+        args = required_arguments + optional_arguments
+
+        args.sort! do |a1, a2|
+          a1_priority = a2_priority = 0
+
+          a1_priority += 2 unless a1.array?
+          a2_priority += 2 unless a2.array?
+          a1_priority += 1 if a1.required?
+          a2_priority += 1 if a2.required?
+
+          if a1_priority > a2_priority
+            -1
+          elsif a2_priority > a1_priority
+            1
+          else
+            0
+          end
+        end
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
+
       # @since 0.7.0
       # @api private
       def self.subcommands
@@ -387,6 +412,7 @@ module Dry
         default_params
         required_arguments
         optional_arguments
+        arguments_sorted_by_usage_order
         subcommands
       ] => "self.class"
 

--- a/lib/dry/cli/usage.rb
+++ b/lib/dry/cli/usage.rb
@@ -54,14 +54,13 @@ module Dry
       def self.arguments(command)
         return unless CLI.command?(command)
 
-        required_arguments = command.required_arguments
-        optional_arguments = command.optional_arguments
+        args = command.arguments_sorted_by_usage_order
+        args.map! do |a|
+          name = a.required? ? a.name.to_s : "[#{a.name}]"
+          name.upcase!
+        end
 
-        required = required_arguments.map { |arg| arg.name.upcase }.join(" ") if required_arguments.any?
-        optional = optional_arguments.map { |arg| "[#{arg.name.upcase}]" }.join(" ") if optional_arguments.any?
-        result = [required, optional].compact
-
-        " #{result.join(" ")}" unless result.empty?
+        " #{args.join(" ")}" unless args.empty?
       end
 
       # @since 0.1.0

--- a/lib/dry/cli/usage.rb
+++ b/lib/dry/cli/usage.rb
@@ -56,7 +56,7 @@ module Dry
 
         args = command.arguments_sorted_by_usage_order
         args.map! do |a|
-          name = a.required? ? a.name.to_s : "[#{a.name}]"
+          name = a.required? ? "#{a.name}" : "[#{a.name}]"
           name.upcase!
         end
 

--- a/lib/dry/cli/usage.rb
+++ b/lib/dry/cli/usage.rb
@@ -56,7 +56,8 @@ module Dry
 
         args = command.arguments_sorted_by_usage_order
         args.map! do |a|
-          name = a.required? ? "#{a.name}" : "[#{a.name}]"
+          # a.to_s raises deprecation warning that it will result in a frozen string in the future
+          name = a.required? ? "#{a.name}" : "[#{a.name}]" # rubocop:disable Style/RedundantInterpolation
           name.upcase!
         end
 

--- a/spec/integration/rendering_spec.rb
+++ b/spec/integration/rendering_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Rendering" do
         foo console                                                # Starts Foo console
         foo db [SUBCOMMAND]
         foo destroy [SUBCOMMAND]
-        foo exec TASK [DIRS]                                       # Execute a task
+        foo exec TASK DIRS                                         # Execute a task
         foo generate [SUBCOMMAND]
         foo greeting [RESPONSE]
         foo hello                                                  # Print a greeting

--- a/spec/integration/spell_checker_spec.rb
+++ b/spec/integration/spell_checker_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Spell checker" do
         foo console                                                # Starts Foo console
         foo db [SUBCOMMAND]
         foo destroy [SUBCOMMAND]
-        foo exec TASK [DIRS]                                       # Execute a task
+        foo exec TASK DIRS                                         # Execute a task
         foo generate [SUBCOMMAND]
         foo greeting [RESPONSE]
         foo hello                                                  # Print a greeting

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -344,8 +344,8 @@ module Foo
       class Exec < Dry::CLI::Command
         desc "Execute a task"
 
+        argument :dirs, desc: "Directories",     type: :array,  required: true
         argument :task, desc: "Task to execute", type: :string, required: true
-        argument :dirs, desc: "Directories",     type: :array,  required: false
 
         def call(task:, dirs: [], **)
           puts "exec - Task: #{task} - Directories: #{dirs.inspect}"


### PR DESCRIPTION
Resolve #144

Using the CLI provided in the issue:

![image](https://github.com/user-attachments/assets/f70a7342-3f6d-4005-9b66-cde5fe5a2834)
