### PR TITLE
Implement argument and option type casting

### DIFF
--- a/lib/dry/cli/option.rb
+++ b/lib/dry/cli/option.rb
@@ -70,6 +70,18 @@ module Dry
         type == :array
       end
 
+      # @since 2.0.0
+      # @api private
+      def integer?
+        type == :integer
+      end
+
+      # @since 2.0.0
+      # @api private
+      def float?
+        type == :float
+      end
+
       # @since 0.1.0
       # @api private
       def default
@@ -121,6 +133,24 @@ module Dry
           .map { |name| name.size == 1 ? "-#{name}" : "--#{name}" }
           .map { |name| boolean? || flag? ? name : "#{name} VALUE" }
       end
+
+      # @since 2.0.0
+      # @api private
+      # rubocop:disable Metrics/PerceivedComplexity
+      def type_cast(value)
+        return value if value.nil?
+
+        if integer?
+          value.to_i
+        elsif float?
+          value.to_f
+        elsif argument? && (boolean? || flag?)
+          %w[0 f false off].include?(value.downcase) ? false : true
+        else
+          value
+        end
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
     end
 
     # Command line argument

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -20,7 +20,7 @@ module Dry
         OptionParser.new do |opts|
           command.options.each do |option|
             opts.on(*option.parser_options) do |value|
-              parsed_options[option.name.to_sym] = value
+              parsed_options[option.name.to_sym] = option.type_cast(value)
             end
           end
 
@@ -77,7 +77,7 @@ module Dry
             result[cmd_arg.name] = arguments[index..]
             break
           else
-            result[cmd_arg.name] = arguments.at(index)
+            result[cmd_arg.name] = cmd_arg.type_cast(arguments.at(index))
           end
         end
 

--- a/spec/unit/dry/cli/option_spec.rb
+++ b/spec/unit/dry/cli/option_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe "Option" do
+  describe "type casting" do
+    it "supports :integer" do
+      o = Dry::CLI::Option.new("test", {type: :integer})
+
+      expect(o.type_cast("42")).to eq(42)
+      expect(o.type_cast("4.2")).to eq(4)
+    end
+
+    it "supports :float" do
+      o = Dry::CLI::Option.new("test", {type: :float})
+
+      expect(o.type_cast("4.2")).to eq(4.2)
+      expect(o.type_cast("42.42")).to eq(42.42)
+    end
+
+    it "supports :string" do
+      o = Dry::CLI::Option.new("test", {type: :string})
+
+      expect(o.type_cast("42")).to eq("42")
+      expect(o.type_cast("42.42")).to eq("42.42")
+      expect(o.type_cast("true")).to eq("true")
+      expect(o.type_cast("this is a string")).to eq("this is a string")
+    end
+
+    it "returns the received value when no type is defined" do
+      o = Dry::CLI::Option.new("test")
+
+      expect(o.type_cast("42")).to eq("42")
+      expect(o.type_cast("42.42")).to eq("42.42")
+      expect(o.type_cast("true")).to eq("true")
+      expect(o.type_cast("this is a string")).to eq("this is a string")
+    end
+
+    it "supports :boolean arguments" do
+      o = Dry::CLI::Argument.new("test", {type: :boolean})
+
+      expect(o.type_cast("true")).to eq(true)
+      expect(o.type_cast("True")).to eq(true)
+      expect(o.type_cast("TRUE")).to eq(true)
+      expect(o.type_cast("t")).to eq(true)
+      expect(o.type_cast("T")).to eq(true)
+      expect(o.type_cast("1")).to eq(true)
+      expect(o.type_cast("42")).to eq(true)
+      expect(o.type_cast("42.42")).to eq(true)
+      expect(o.type_cast("this is considered true")).to eq(true)
+
+      expect(o.type_cast("false")).to eq(false)
+      expect(o.type_cast("False")).to eq(false)
+      expect(o.type_cast("FALSE")).to eq(false)
+      expect(o.type_cast("off")).to eq(false)
+      expect(o.type_cast("Off")).to eq(false)
+      expect(o.type_cast("OFF")).to eq(false)
+      expect(o.type_cast("f")).to eq(false)
+      expect(o.type_cast("F")).to eq(false)
+      expect(o.type_cast("0")).to eq(false)
+    end
+
+    it "considers :flag arguments as :boolean" do
+      o = Dry::CLI::Argument.new("test", {type: :flag})
+
+      expect(o.type_cast("true")).to eq(true)
+      expect(o.type_cast("True")).to eq(true)
+      expect(o.type_cast("TRUE")).to eq(true)
+      expect(o.type_cast("t")).to eq(true)
+      expect(o.type_cast("T")).to eq(true)
+      expect(o.type_cast("1")).to eq(true)
+      expect(o.type_cast("42")).to eq(true)
+      expect(o.type_cast("42.42")).to eq(true)
+      expect(o.type_cast("this is considered true")).to eq(true)
+
+      expect(o.type_cast("false")).to eq(false)
+      expect(o.type_cast("False")).to eq(false)
+      expect(o.type_cast("FALSE")).to eq(false)
+      expect(o.type_cast("off")).to eq(false)
+      expect(o.type_cast("Off")).to eq(false)
+      expect(o.type_cast("OFF")).to eq(false)
+      expect(o.type_cast("f")).to eq(false)
+      expect(o.type_cast("F")).to eq(false)
+      expect(o.type_cast("0")).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
As reported in the issue #129, although we have the `type` config when defining arguments and options, we don't type cast the value for the user, which for some may seem like a bug.

This PR implement a simple type casting logic for some types. Since some types that users currently receive as string will start to be received as another type (e.g. integer), this is a breaking change.

The CLI bellow demonstrates all available types:

```ruby
require 'dry/cli'

module Demo
  extend Dry::CLI::Registry

  class TypeCast < Dry::CLI::Command
    argument :a_int, type: :integer
    argument :a_flo, type: :float
    argument :a_boo, type: :boolean
    argument :a_fla, type: :flag
    argument :a_str, type: :string
    argument :a_arr, type: :array
    option :o_int, type: :integer
    option :o_flo, type: :float
    option :o_boo, type: :boolean
    option :o_fla, type: :flag
    option :o_str, type: :string
    option :o_arr, type: :array

    def call(a_int:, a_flo:, a_boo:, a_fla:, a_str:, a_arr:, o_int:, o_flo:, o_boo:, o_fla:, o_str:, o_arr:, **)
      puts <<~HEREDOC
        Arguments:
          #{a_int}\t\t\t#{a_int.class}
          #{a_flo}\t\t\t#{a_flo.class}
          #{a_boo}\t\t\t#{a_boo.class}
          #{a_fla}\t\t\t#{a_fla.class}
          #{a_str}\t#{a_str.class}
          #{a_arr}\t#{a_arr.class}
        Options:
          #{o_int}\t\t\t#{o_int.class}
          #{o_flo}\t\t\t#{o_flo.class}
          #{o_boo}\t\t\t#{o_boo.class}
          #{o_fla}\t\t\t#{o_fla.class}
          #{o_str}\t#{o_str.class}
          #{o_arr}\t#{o_arr.class}
      HEREDOC
    end
  end

  register "type-cast", TypeCast
end

Dry::CLI.new(Demo).call
```

The output:
```bash
$ demo type-cast 42 42.42 t off 'This is a string' 1 2 3 --o_int=42 --o_flo=42.42 --no-o_boo --o_fla --o_str='this is a string' --o_arr=1,2,3

# Before:
Arguments:
  42                    String
  42.42                 String
  t                     String
  off                   String
  This is a string      String
  ["1", "2", "3"]       Array
Options:
  42                    String
  42.42                 String
  false                 FalseClass
  true                  TrueClass
  this is a string      String
  ["1", "2", "3"]       Array

# After:
Arguments:
  42                    Integer
  42.42                 Float
  true                  TrueClass
  false                 FalseClass
  This is a string      String
  ["1", "2", "3"]       Array
Options:
  42                    Integer
  42.42                 Float
  false                 FalseClass
  true                  TrueClass
  this is a string      String
  ["1", "2", "3"]       Array
```