### PR TITLE
Add support for Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+        - "3.4"
         - "3.3"
         - "3.2"
         - "3.1"
-        - "3.0"
         include:
           - ruby: "3.2"
             coverage: "true"

--- a/spec/integration/inherited_commands_spec.rb
+++ b/spec/integration/inherited_commands_spec.rb
@@ -18,8 +18,15 @@ RSpec.describe "Inherited commands" do
 
   it "works for subclasses" do
     output = `based subrun application_name command_to_run`
-    expect(output).to eq(
-      "Run - App: application_name - Command: command_to_run - Options: {:verbosity=>\"INFO\"}\n"
-    )
+
+    if RUBY_VERSION < "3.4"
+      expect(output).to eq(
+        "Run - App: application_name - Command: command_to_run - Options: {:verbosity=>\"INFO\"}\n"
+      )
+    else
+      expect(output).to eq(
+        "Run - App: application_name - Command: command_to_run - Options: {verbosity: \"INFO\"}\n"
+      )
+    end
   end
 end

--- a/spec/integration/inline_spec.rb
+++ b/spec/integration/inline_spec.rb
@@ -33,11 +33,20 @@ RSpec.describe "Inline" do
 
     it "with underscored option_one" do
       output = `inline first_arg -1 test2 -bd test3`
-      expect(output).to eq(
-        "mandatory_arg: first_arg. optional_arg: optional_arg. " \
-        'Options: {:option_with_default=>"test3", :option_one=>"test2", :boolean_option=>true}' \
-        "\n"
-      )
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          'Options: {:option_with_default=>"test3", :option_one=>"test2", :boolean_option=>true}' \
+          "\n"
+        )
+      else
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          'Options: {option_with_default: "test3", option_one: "test2", boolean_option: true}' \
+          "\n"
+        )
+      end
     end
   end
 end

--- a/spec/integration/single_command_spec.rb
+++ b/spec/integration/single_command_spec.rb
@@ -40,18 +40,34 @@ RSpec.describe "Single command" do
 
     it "with option_one" do
       output = `baz first_arg --option-one=test2`
-      expect(output).to eq(
-        "mandatory_arg: first_arg. optional_arg: optional_arg. " \
-        "Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
-      )
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
+        )
+      else
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {option_with_default: \"test\", option_one: \"test2\"}\n"
+        )
+      end
     end
 
     it "with combination of aliases" do
       output = `baz first_arg -bd test3`
-      expect(output).to eq(
-        "mandatory_arg: first_arg. optional_arg: optional_arg. " \
-        "Options: {:option_with_default=>\"test3\", :boolean_option=>true}\n"
-      )
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {:option_with_default=>\"test3\", :boolean_option=>true}\n"
+        )
+      else
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {option_with_default: \"test3\", boolean_option: true}\n"
+        )
+      end
     end
   end
 

--- a/spec/integration/third_party_gems_spec.rb
+++ b/spec/integration/third_party_gems_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe "Third-party gems" do
         after callback (class), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
         after callback (object), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
       OUTPUT
-      expect(output).to eq(expected)
     else
       expected = <<~OUTPUT
         before command callback Foo::Webpack::CLI::CallbacksCommand {url: "https://hanamirb.test", dir: "."}
@@ -25,8 +24,7 @@ RSpec.describe "Third-party gems" do
         after callback (class), 2 arg(s): {url: "https://hanamirb.test", dir: "."}
         after callback (object), 2 arg(s): {url: "https://hanamirb.test", dir: "."}
       OUTPUT
-      expect(output).to eq(expected)
     end
-
+    expect(output).to eq(expected)
   end
 end

--- a/spec/integration/third_party_gems_spec.rb
+++ b/spec/integration/third_party_gems_spec.rb
@@ -4,15 +4,29 @@ RSpec.describe "Third-party gems" do
   it "allows to add callbacks as a block" do
     output = `foo callbacks . --url=https://hanamirb.test`
 
-    expected = <<~OUTPUT
-      before command callback Foo::Webpack::CLI::CallbacksCommand {:url=>"https://hanamirb.test", :dir=>"."}
-      before callback (class), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
-      before callback (object), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
-      dir: ., url: "https://hanamirb.test"
-      after command callback Foo::Webpack::CLI::CallbacksCommand {:url=>"https://hanamirb.test", :dir=>"."}
-      after callback (class), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
-      after callback (object), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
-    OUTPUT
-    expect(output).to eq(expected)
+    if RUBY_VERSION < "3.4"
+      expected = <<~OUTPUT
+        before command callback Foo::Webpack::CLI::CallbacksCommand {:url=>"https://hanamirb.test", :dir=>"."}
+        before callback (class), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
+        before callback (object), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
+        dir: ., url: "https://hanamirb.test"
+        after command callback Foo::Webpack::CLI::CallbacksCommand {:url=>"https://hanamirb.test", :dir=>"."}
+        after callback (class), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
+        after callback (object), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
+      OUTPUT
+      expect(output).to eq(expected)
+    else
+      expected = <<~OUTPUT
+        before command callback Foo::Webpack::CLI::CallbacksCommand {url: "https://hanamirb.test", dir: "."}
+        before callback (class), 2 arg(s): {url: "https://hanamirb.test", dir: "."}
+        before callback (object), 2 arg(s): {url: "https://hanamirb.test", dir: "."}
+        dir: ., url: "https://hanamirb.test"
+        after command callback Foo::Webpack::CLI::CallbacksCommand {url: "https://hanamirb.test", dir: "."}
+        after callback (class), 2 arg(s): {url: "https://hanamirb.test", dir: "."}
+        after callback (object), 2 arg(s): {url: "https://hanamirb.test", dir: "."}
+      OUTPUT
+      expect(output).to eq(expected)
+    end
+
   end
 end

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -29,34 +29,84 @@ RSpec.shared_examples "Commands" do |cli|
   context "works with params" do
     it "without params" do
       output = capture_output { cli.call(arguments: ["server"]) }
-      expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"]}\n")
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"]}\n")
+      else
+        expect(output).to eq("server - {code_reloading: true, deps: [\"dep1\", \"dep2\"]}\n")
+      end
     end
 
     it "a param using space" do
       output = capture_output { cli.call(arguments: %w[server --server thin]) }
-      expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :server=>\"thin\"}\n")
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :server=>\"thin\"}\n")
+      else
+        expect(output).to eq("server - {code_reloading: true, deps: [\"dep1\", \"dep2\"], server: \"thin\"}\n")
+      end
     end
 
     it "a param using equal sign" do
       output = capture_output { cli.call(arguments: %w[server --host=localhost]) }
-      expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :host=>\"localhost\"}\n")
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :host=>\"localhost\"}\n")
+      else
+        expect(output).to eq("server - {code_reloading: true, deps: [\"dep1\", \"dep2\"], host: \"localhost\"}\n")
+      end
     end
 
-    it "a param using alias" do
-      output = capture_output { cli.call(arguments: %w[options-with-aliases -u test]) }
-      expect(output).to eq("options with aliases - {:opt=>false, :url=>\"test\"}\n")
+    context "with aliases" do
+      it "includes a space" do
+        output = capture_output { cli.call(arguments: %w[options-with-aliases -u test]) }
 
-      output = capture_output { cli.call(arguments: %w[options-with-aliases -utest]) }
-      expect(output).to eq("options with aliases - {:opt=>false, :url=>\"test\"}\n")
+        if RUBY_VERSION < "3.4"
+          expect(output).to eq("options with aliases - {:opt=>false, :url=>\"test\"}\n")
+        else
+          expect(output).to eq("options with aliases - {opt: false, url: \"test\"}\n")
+        end
+      end
 
-      output = capture_output { cli.call(arguments: %w[options-with-aliases -f -u test]) }
-      expect(output).to eq("options with aliases - {:opt=>false, :flag=>true, :url=>\"test\"}\n")
+      it "doesn't include a space" do
+        output = capture_output { cli.call(arguments: %w[options-with-aliases -utest]) }
 
-      output = capture_output { cli.call(arguments: %w[options-with-aliases -o]) }
-      expect(output).to eq("options with aliases - {:opt=>true}\n")
+        if RUBY_VERSION < "3.4"
+          expect(output).to eq("options with aliases - {:opt=>false, :url=>\"test\"}\n")
+        else
+          expect(output).to eq("options with aliases - {opt: false, url: \"test\"}\n")
+        end
+      end
 
-      output = capture_output { cli.call(arguments: %w[options-with-aliases -of]) }
-      expect(output).to eq("options with aliases - {:opt=>true, :flag=>true}\n")
+      it "has multiple aliases" do
+        output = capture_output { cli.call(arguments: %w[options-with-aliases -f -u test]) }
+
+        if RUBY_VERSION < "3.4"
+          expect(output).to eq("options with aliases - {:opt=>false, :flag=>true, :url=>\"test\"}\n")
+        else
+          expect(output).to eq("options with aliases - {opt: false, flag: true, url: \"test\"}\n")
+        end
+      end
+
+      it "uses an alias to override a default value" do
+        output = capture_output { cli.call(arguments: %w[options-with-aliases -o]) }
+
+        if RUBY_VERSION < "3.4"
+          expect(output).to eq("options with aliases - {:opt=>true}\n")
+        else
+          expect(output).to eq("options with aliases - {opt: true}\n")
+        end
+      end
+
+      it "uses an alias to override a default value, combined with a flag alias" do
+        output = capture_output { cli.call(arguments: %w[options-with-aliases -of]) }
+
+        if RUBY_VERSION < "3.4"
+          expect(output).to eq("options with aliases - {:opt=>true, :flag=>true}\n")
+        else
+          expect(output).to eq("options with aliases - {opt: true, flag: true}\n")
+        end
+      end
     end
 
     it "a param with unknown param" do
@@ -66,18 +116,38 @@ RSpec.shared_examples "Commands" do |cli|
 
     it "with boolean param" do
       output = capture_output { cli.call(arguments: ["server"]) }
-      expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"]}\n")
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"]}\n")
+      else
+        expect(output).to eq("server - {code_reloading: true, deps: [\"dep1\", \"dep2\"]}\n")
+      end
 
       output = capture_output { cli.call(arguments: %w[server --no-code-reloading]) }
-      expect(output).to eq("server - {:code_reloading=>false, :deps=>[\"dep1\", \"dep2\"]}\n")
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq("server - {:code_reloading=>false, :deps=>[\"dep1\", \"dep2\"]}\n")
+      else
+        expect(output).to eq("server - {code_reloading: false, deps: [\"dep1\", \"dep2\"]}\n")
+      end
     end
 
     it "with flag param" do
       output = capture_output { cli.call(arguments: ["server"]) }
-      expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"]}\n")
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"]}\n")
+      else
+        expect(output).to eq("server - {code_reloading: true, deps: [\"dep1\", \"dep2\"]}\n")
+      end
 
       output = capture_output { cli.call(arguments: %w[server --quiet]) }
-      expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :quiet=>true}\n")
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :quiet=>true}\n")
+      else
+        expect(output).to eq("server - {code_reloading: true, deps: [\"dep1\", \"dep2\"], quiet: true}\n")
+      end
     end
 
     context "with array param" do

--- a/spec/support/shared_examples/inherited_commands.rb
+++ b/spec/support/shared_examples/inherited_commands.rb
@@ -143,26 +143,46 @@ RSpec.shared_examples "Inherited commands" do |cli|
   context "with inherited options" do
     it "run has default verbosity_level" do
       output = capture_output { cli.call(arguments: %w[i run application_name command_name]) }
-      expect(output).to include('Options: {:verbosity=>"INFO"}')
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to include('Options: {:verbosity=>"INFO"}')
+      else
+        expect(output).to include('Options: {verbosity: "INFO"}')
+      end
     end
 
     it "subrun has default verbosity_level too" do
       output = capture_output { cli.call(arguments: %w[i subrun application_name command_name]) }
-      expect(output).to include('Options: {:verbosity=>"INFO"}')
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to include('Options: {:verbosity=>"INFO"}')
+      else
+        expect(output).to include('Options: {verbosity: "INFO"}')
+      end
     end
 
     it "addons has verbosity_level set to debug" do
       output = capture_output do
         cli.call(arguments: %w[i addons application_name --verbosity=DEBUG])
       end
-      expect(output).to include("Options: {:verbosity=>\"DEBUG\", :json=>false}")
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to include("Options: {:verbosity=>\"DEBUG\", :json=>false}")
+      else
+        expect(output).to include("Options: {verbosity: \"DEBUG\", json: false}")
+      end
     end
 
     it "logs has verbosity_level set to WARNING" do
       output = capture_output do
         cli.call(arguments: %w[i logs application_name --verbosity=WARNING])
       end
-      expect(output).to include("Options: {:verbosity=>\"WARNING\"}")
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to include("Options: {:verbosity=>\"WARNING\"}")
+      else
+        expect(output).to include("Options: {verbosity: \"WARNING\"}")
+      end
     end
   end
 

--- a/spec/support/shared_examples/subcommands.rb
+++ b/spec/support/shared_examples/subcommands.rb
@@ -28,23 +28,45 @@ RSpec.shared_examples "Subcommands" do |cli|
 
     it "a param using space" do
       output = capture_output { cli.call(arguments: %w[server --port 2306]) }
-      expect(output).to eq(
-        "server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :port=>\"2306\"}\n"
-      )
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq(
+          "server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :port=>\"2306\"}\n"
+        )
+
+      else
+        expect(output).to eq(
+          "server - {code_reloading: true, deps: [\"dep1\", \"dep2\"], port: \"2306\"}\n"
+        )
+      end
     end
 
     it "a param using equal sign" do
       output = capture_output { cli.call(arguments: %w[server --port=2306]) }
-      expect(output).to eq(
-        "server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :port=>\"2306\"}\n"
-      )
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq(
+          "server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :port=>\"2306\"}\n"
+        )
+      else
+        expect(output).to eq(
+          "server - {code_reloading: true, deps: [\"dep1\", \"dep2\"], port: \"2306\"}\n"
+        )
+      end
     end
 
     it "a param using alias" do
       output = capture_output { cli.call(arguments: %w[server -p 2306]) }
-      expect(output).to eq(
-        "server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :port=>\"2306\"}\n"
-      )
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq(
+          "server - {:code_reloading=>true, :deps=>[\"dep1\", \"dep2\"], :port=>\"2306\"}\n"
+        )
+      else
+        expect(output).to eq(
+          "server - {code_reloading: true, deps: [\"dep1\", \"dep2\"], port: \"2306\"}\n"
+        )
+      end
     end
 
     it "with help param" do
@@ -88,12 +110,22 @@ RSpec.shared_examples "Subcommands" do |cli|
 
       it "more than one param and with optional params" do
         output = capture_output { cli.call(arguments: %w[generate action web users#index --url=/signin]) }
-        expect(output).to eq("generate action - app: web, action: users#index, options: {:skip_view=>false, :url=>\"/signin\"}\n")
+
+        if RUBY_VERSION < "3.4"
+          expect(output).to eq("generate action - app: web, action: users#index, options: {:skip_view=>false, :url=>\"/signin\"}\n")
+        else
+          expect(output).to eq("generate action - app: web, action: users#index, options: {skip_view: false, url: \"/signin\"}\n")
+        end
       end
 
       it "more than one param and with boolean params" do
         output = capture_output { cli.call(arguments: %w[generate action web users#index --skip-view --url=/signin]) }
-        expect(output).to eq("generate action - app: web, action: users#index, options: {:skip_view=>true, :url=>\"/signin\"}\n")
+
+        if RUBY_VERSION < "3.4"
+          expect(output).to eq("generate action - app: web, action: users#index, options: {:skip_view=>true, :url=>\"/signin\"}\n")
+        else
+          expect(output).to eq("generate action - app: web, action: users#index, options: {skip_view: true, url: \"/signin\"}\n")
+        end
       end
 
       it "more than required params" do

--- a/spec/support/shared_examples/third_party_gems.rb
+++ b/spec/support/shared_examples/third_party_gems.rb
@@ -38,8 +38,6 @@ RSpec.shared_examples "Third-party gems" do |cli|
           after callback (object), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
         OUTPUT
 
-        output = capture_output { cli.call(arguments: %w[callbacks . --url=https://hanamirb.test]) }
-        expect(output).to eq(expected)
       else
         expected = <<~OUTPUT
           before command callback Webpack::CLI::CallbacksCommand {url: "https://hanamirb.test", dir: "."}
@@ -51,9 +49,9 @@ RSpec.shared_examples "Third-party gems" do |cli|
           after callback (object), 2 arg(s): {url: "https://hanamirb.test", dir: "."}
         OUTPUT
 
-        output = capture_output { cli.call(arguments: %w[callbacks . --url=https://hanamirb.test]) }
-        expect(output).to eq(expected)
       end
+      output = capture_output { cli.call(arguments: %w[callbacks . --url=https://hanamirb.test]) }
+      expect(output).to eq(expected)
     end
   end
 

--- a/spec/support/shared_examples/third_party_gems.rb
+++ b/spec/support/shared_examples/third_party_gems.rb
@@ -27,18 +27,33 @@ RSpec.shared_examples "Third-party gems" do |cli|
 
   context "callbacks" do
     it "allows to add callbacks as a block" do
-      expected = <<~OUTPUT
-        before command callback Webpack::CLI::CallbacksCommand {:url=>"https://hanamirb.test", :dir=>"."}
-        before callback (class), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
-        before callback (object), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
-        dir: ., url: "https://hanamirb.test"
-        after command callback Webpack::CLI::CallbacksCommand {:url=>"https://hanamirb.test", :dir=>"."}
-        after callback (class), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
-        after callback (object), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
-      OUTPUT
+      if RUBY_VERSION < "3.4"
+        expected = <<~OUTPUT
+          before command callback Webpack::CLI::CallbacksCommand {:url=>"https://hanamirb.test", :dir=>"."}
+          before callback (class), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
+          before callback (object), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
+          dir: ., url: "https://hanamirb.test"
+          after command callback Webpack::CLI::CallbacksCommand {:url=>"https://hanamirb.test", :dir=>"."}
+          after callback (class), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
+          after callback (object), 2 arg(s): {:url=>"https://hanamirb.test", :dir=>"."}
+        OUTPUT
 
-      output = capture_output { cli.call(arguments: %w[callbacks . --url=https://hanamirb.test]) }
-      expect(output).to eq(expected)
+        output = capture_output { cli.call(arguments: %w[callbacks . --url=https://hanamirb.test]) }
+        expect(output).to eq(expected)
+      else
+        expected = <<~OUTPUT
+          before command callback Webpack::CLI::CallbacksCommand {url: "https://hanamirb.test", dir: "."}
+          before callback (class), 2 arg(s): {url: "https://hanamirb.test", dir: "."}
+          before callback (object), 2 arg(s): {url: "https://hanamirb.test", dir: "."}
+          dir: ., url: "https://hanamirb.test"
+          after command callback Webpack::CLI::CallbacksCommand {url: "https://hanamirb.test", dir: "."}
+          after callback (class), 2 arg(s): {url: "https://hanamirb.test", dir: "."}
+          after callback (object), 2 arg(s): {url: "https://hanamirb.test", dir: "."}
+        OUTPUT
+
+        output = capture_output { cli.call(arguments: %w[callbacks . --url=https://hanamirb.test]) }
+        expect(output).to eq(expected)
+      end
     end
   end
 

--- a/spec/unit/dry/cli/cli_spec.rb
+++ b/spec/unit/dry/cli/cli_spec.rb
@@ -58,66 +58,130 @@ RSpec.describe "CLI" do
 
     it "with required_argument" do
       output = capture_output { cli.call(arguments: ["first_arg"]) }
-      expect(output).to eq(
-        "mandatory_arg: first_arg. optional_arg: optional_arg. " \
-        "Options: {:option_with_default=>\"test\"}\n"
-      )
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {:option_with_default=>\"test\"}\n"
+        )
+      else
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {option_with_default: \"test\"}\n"
+        )
+      end
     end
 
     it "with optional_arg" do
       output = capture_output { cli.call(arguments: %w[first_arg opt_arg]) }
-      expect(output).to eq(
-        "mandatory_arg: first_arg. optional_arg: opt_arg. " \
-        "Options: {:option_with_default=>\"test\", :args=>[\"opt_arg\"]}\n"
-      )
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: opt_arg. " \
+          "Options: {:option_with_default=>\"test\", :args=>[\"opt_arg\"]}\n"
+        )
+      else
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: opt_arg. " \
+          "Options: {option_with_default: \"test\", args: [\"opt_arg\"]}\n"
+        )
+      end
     end
 
     it "with underscored option_one" do
       output = capture_output { cli.call(arguments: %w[first_arg --option_one=test2]) }
-      expect(output).to eq(
-        "mandatory_arg: first_arg. optional_arg: optional_arg. " \
-        "Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
-      )
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
+        )
+      else
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {option_with_default: \"test\", option_one: \"test2\"}\n"
+        )
+      end
     end
 
     it "with option_one alias" do
       output = capture_output { cli.call(arguments: %w[first_arg -1 test2]) }
-      expect(output).to eq(
-        "mandatory_arg: first_arg. optional_arg: optional_arg. " \
-        "Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
-      )
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {:option_with_default=>\"test\", :option_one=>\"test2\"}\n"
+        )
+      else
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {option_with_default: \"test\", option_one: \"test2\"}\n"
+        )
+      end
     end
 
     it "with underscored boolean_option" do
       output = capture_output { cli.call(arguments: %w[first_arg --boolean_option]) }
-      expect(output).to eq(
-        "mandatory_arg: first_arg. optional_arg: optional_arg. " \
-        "Options: {:option_with_default=>\"test\", :boolean_option=>true}\n"
-      )
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {:option_with_default=>\"test\", :boolean_option=>true}\n"
+        )
+      else
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {option_with_default: \"test\", boolean_option: true}\n"
+        )
+      end
     end
 
     it "with boolean_option alias" do
       output = capture_output { cli.call(arguments: %w[first_arg -b]) }
-      expect(output).to eq(
-        "mandatory_arg: first_arg. optional_arg: optional_arg. " \
-        "Options: {:option_with_default=>\"test\", :boolean_option=>true}\n"
-      )
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {:option_with_default=>\"test\", :boolean_option=>true}\n"
+        )
+      else
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {option_with_default: \"test\", boolean_option: true}\n"
+        )
+      end
     end
 
     it "with underscoreed option_with_default alias" do
       output = capture_output { cli.call(arguments: %w[first_arg --option_with_default=test3]) }
-      expect(output).to eq(
-        "mandatory_arg: first_arg. optional_arg: optional_arg. " \
-        "Options: {:option_with_default=>\"test3\"}\n"
-      )
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {:option_with_default=>\"test3\"}\n"
+        )
+      else
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {option_with_default: \"test3\"}\n"
+        )
+      end
     end
 
     it "with combination of aliases" do
       output = capture_output { cli.call(arguments: %w[first_arg -bd test3]) }
-      expect(output).to eq(
-        "mandatory_arg: first_arg. optional_arg: optional_arg. " \
-        "Options: {:option_with_default=>\"test3\", :boolean_option=>true}\n"
-      )
+
+      if RUBY_VERSION < "3.4"
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {:option_with_default=>\"test3\", :boolean_option=>true}\n"
+        )
+      else
+        expect(output).to eq(
+          "mandatory_arg: first_arg. optional_arg: optional_arg. " \
+          "Options: {option_with_default: \"test3\", boolean_option: true}\n"
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
This also drops Ruby 3.0 from CI.

The README says Ruby 2.4+ is supported. Do we really want that? I feel like dropping support for EOL'd versions of Ruby is acceptable.