### PR TITLE
Add support for unlimited nested command prefixes

### DIFF
--- a/lib/dry/cli/registry.rb
+++ b/lib/dry/cli/registry.rb
@@ -318,9 +318,18 @@ module Dry
         # @since 0.1.0
         #
         # @see Dry::CLI::Registry#register
-        def register(name, command, aliases: [], hidden: false)
+        def register(name, command = nil, aliases: [], hidden: false, &block)
           command_name = "#{prefix} #{name}"
           registry.set(command_name, command, aliases, hidden)
+
+          if block_given?
+            prefix = self.class.new(registry, command_name, aliases, hidden)
+            if block.arity.zero?
+              prefix.instance_eval(&block)
+            else
+              yield(prefix)
+            end
+          end
         end
 
         private

--- a/spec/integration/rendering_spec.rb
+++ b/spec/integration/rendering_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Rendering" do
         foo generate [SUBCOMMAND]
         foo greeting [RESPONSE]
         foo hello                                                  # Print a greeting
+        foo nested [SUBCOMMAND]
         foo new PROJECT                                            # Generate a new Foo project
         foo root-command [ARGUMENT|SUBCOMMAND]                     # Root command with arguments and subcommands
         foo routes                                                 # Print routes

--- a/spec/integration/spell_checker_spec.rb
+++ b/spec/integration/spell_checker_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Spell checker" do
         foo generate [SUBCOMMAND]
         foo greeting [RESPONSE]
         foo hello                                                  # Print a greeting
+        foo nested [SUBCOMMAND]
         foo new PROJECT                                            # Generate a new Foo project
         foo root-command [ARGUMENT|SUBCOMMAND]                     # Root command with arguments and subcommands
         foo routes                                                 # Print routes

--- a/spec/integration/subcommands_spec.rb
+++ b/spec/integration/subcommands_spec.rb
@@ -57,4 +57,30 @@ RSpec.describe "Subcommands" do
       expect(output).to eq(expected)
     end
   end
+
+  context "it works with multi nested prefixed commands" do
+    it "nests once" do
+      output = `foo nested one`
+
+      expected = "I'm a one level nested command\n"
+
+      expect(output).to eq(expected)
+    end
+
+    it "nests twice" do
+      output = `foo nested one two`
+
+      expected = "I'm a two level nested command\n"
+
+      expect(output).to eq(expected)
+    end
+
+    it "nests thrice" do
+      output = `foo nested one two three`
+
+      expected = "I'm a three level nested command\n"
+
+      expect(output).to eq(expected)
+    end
+  end
 end

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -433,6 +433,32 @@ module Foo
           end
         end
       end
+
+      module PrefixCommands
+        class NestedOnceCommand < Dry::CLI::Command
+          desc "A nested sub command"
+
+          def call(**_params)
+            puts "I'm a one level nested command"
+          end
+        end
+
+        class NestedTwiceCommand < Dry::CLI::Command
+          desc "A nested nested sub command"
+
+          def call(**_params)
+            puts "I'm a two level nested command"
+          end
+        end
+
+        class NestedThriceCommand < Dry::CLI::Command
+          desc "A nested nested nested sub command"
+
+          def call(**_params)
+            puts "I'm a three level nested command"
+          end
+        end
+      end
     end
   end
 end
@@ -480,6 +506,14 @@ Foo::CLI::Commands.register "root-command sub-command", Foo::CLI::Commands::Root
 Foo::CLI::Commands.register "variadic default",                    Foo::CLI::Commands::VariadicArguments
 Foo::CLI::Commands.register "variadic with-mandatory",             Foo::CLI::Commands::MandatoryAndVariadicArguments
 Foo::CLI::Commands.register "variadic with-mandatory-and-options", Foo::CLI::Commands::MandatoryOptionsAndVariadicArguments
+
+Foo::CLI::Commands.register "nested" do
+  register "one", Foo::CLI::Commands::PrefixCommands::NestedOnceCommand do
+    register "two", Foo::CLI::Commands::PrefixCommands::NestedTwiceCommand do
+      register "three", Foo::CLI::Commands::PrefixCommands::NestedThriceCommand
+    end
+  end
+end
 
 module Foo
   module Webpack


### PR DESCRIPTION
Previously, Dry::CLI supported grouped commands via prefixes, but only one level deep. This change extends the internal DSL to allow recursively nested `register` blocks, enabling deeply nested command hierarchies like:

```shell
my-cli foo bar baz qux
```

This improves organization for complex CLI apps with multiple levels of subcommands.