### PR TITLE
Add `stderr`, `stdin`, and `stdout` support for `Dry::CLI`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Changed
 
+- [POTENTIALLY BREAKING] `Dry::CLI::Command`'s constructor now takes three keyword arguments: `stdout:`, `stdin:`, and `:stderr`. They can be used to inject I/O stream, which is useful for testing.
 - The `example` DSL now takes the example and its description as separate arguments, called once per example. Previously, examples were passed as a single array of strings with the description embedded after a `#`. (@aaronmallen and @timriley in #152)
 
   ```ruby

--- a/lib/dry/cli.rb
+++ b/lib/dry/cli.rb
@@ -83,12 +83,13 @@ module Dry
     # Invoke the CLI
     #
     # @param arguments [Array<string>] the command line arguments (defaults to `ARGV`)
-    # @param out [IO] the standard output (defaults to `$stdout`)
-    # @param err [IO] the error output (defaults to `$stderr`)
+    # @param stderr [IO] the error output (defaults to `$stderr`)
+    # @param stdin [IO] the standard input (defaults to `$stdin`)
+    # @param stdout [IO] the standard output (defaults to `$stdout`)
     #
     # @since 0.1.0
-    def call(arguments: ARGV, out: $stdout, err: $stderr)
-      @out, @err = out, err
+    def call(arguments: ARGV, stderr: $stderr, stdin: $stdin, stdout: $stdout)
+      @stderr, @stdin, @stdout = stderr, stdin, stdout
       kommand ? perform_command(arguments) : perform_registry(arguments)
     rescue SignalException => exception
       signal_exception(exception)
@@ -108,11 +109,15 @@ module Dry
 
     # @since 0.6.0
     # @api private
-    attr_reader :out
+    attr_reader :stderr
+
+    # @since unreleased
+    # @api private
+    attr_reader :stdin
 
     # @since 0.6.0
     # @api private
-    attr_reader :err
+    attr_reader :stdout
 
     # Invoke the CLI if singular command passed
     #
@@ -123,10 +128,6 @@ module Dry
     # @api private
     def perform_command(arguments)
       command, args = parse(kommand, arguments, [])
-
-      command.instance_variable_set(:@err, err) unless command.instance_variable_defined?(:@err)
-      command.instance_variable_set(:@out, out) unless command.instance_variable_defined?(:@out)
-
       command.call(**args)
     end
 
@@ -142,10 +143,7 @@ module Dry
       return spell_checker(result, arguments) unless result.found?
 
       command, args = parse(result.command, result.arguments, result.names)
-      return err.puts(Usage.call(result)) unless command.respond_to?(:call)
-
-      command.instance_variable_set(:@err, err) unless command.instance_variable_defined?(:@err)
-      command.instance_variable_set(:@out, out) unless command.instance_variable_defined?(:@out)
+      return stderr.puts(Usage.call(result)) unless command.respond_to?(:call)
 
       result.before_callbacks.run(command, **args)
       command.call(**args)
@@ -179,28 +177,31 @@ module Dry
     # @since 0.6.0
     # @api private
     def build_command(command)
-      command.is_a?(Class) ? command.new : command
+      return command unless command.is_a?(Class)
+      return command.new(stderr: stderr, stdin: stdin, stdout: stdout) if CLI.command?(command)
+
+      command.new
     end
 
     # @since 0.6.0
     # @api private
     def help(command, prog_name)
-      out.puts Banner.call(command, prog_name)
+      stdout.puts Banner.call(command, prog_name)
       exit(0) # Successful exit
     end
 
     # @since 0.6.0
     # @api private
     def error(result)
-      err.puts(result.error)
+      stderr.puts(result.error)
       exit(1)
     end
 
     # @since 1.1.1
     def spell_checker(result, arguments)
       spell_checker = SpellChecker.call(result, arguments)
-      err.puts "#{spell_checker}\n\n" if spell_checker
-      err.puts Usage.call(result)
+      stderr.puts "#{spell_checker}\n\n" if spell_checker
+      stderr.puts Usage.call(result)
       exit(1)
     end
 

--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -399,6 +399,14 @@ module Dry
         superclass_variable_dup(:@options)
       end
 
+      # @since unreleased
+      # @api private
+      def initialize(stderr: $stderr, stdin: $stdin, stdout: $stdout)
+        @stderr = stderr
+        @stdin  = stdin
+        @stdout = stdout
+      end
+
       extend Forwardable
 
       delegate %i[
@@ -421,31 +429,44 @@ module Dry
       # @example
       #   class MyCommand
       #     def call
-      #       out.puts "Hello World!"
+      #       stdout.puts "Hello World!"
       #       exit(0)
       #     rescue StandardError => e
-      #       err.puts "Uh oh: #{e.message}"
+      #       stderr.puts "Uh oh: #{e.message}"
       #       exit(1)
       #     end
       #   end
       #
       # @since unreleased
       # @return [IO]
-      attr_reader :err
+      attr_reader :stderr
 
-      # The standard output object used to print messaging
+      # The standard input stream used for reading input
       #
       # @example
       #   class MyCommand
       #     def call
-      #       out.puts "Hello World!"
-      #       exit(0)
+      #       name = stdin.gets.chomp
+      #       stdout.puts "Hello #{name}!"
       #     end
       #   end
       #
       # @since unreleased
       # @return [IO]
-      attr_reader :out
+      attr_reader :stdin
+
+      # The standard output stream used for normal output
+      #
+      # @example
+      #   class MyCommand
+      #     def call
+      #       stdout.puts "Hello World!"
+      #     end
+      #   end
+      #
+      # @since unreleased
+      # @return [IO]
+      attr_reader :stdout
     end
   end
 end

--- a/lib/dry/cli/inline.rb
+++ b/lib/dry/cli/inline.rb
@@ -60,13 +60,13 @@ module Dry
       #   end
       #
       # @since 0.6.0
-      def run(arguments: ARGV, out: $stdout)
+      def run(arguments: ARGV, stdout: $stdout)
         command = AnonymousCommand
         command.define_method(:call) do |**args|
           yield(**args)
         end
 
-        Dry.CLI(command).call(arguments: arguments, out: out)
+        Dry.CLI(command).call(arguments: arguments, stdout: stdout)
       end
     end
   end

--- a/spec/support/fixtures/baz_command.rb
+++ b/spec/support/fixtures/baz_command.rb
@@ -5,7 +5,7 @@ module Baz
     desc "Baz command line interface"
     argument :mandatory_arg, required: true, aliases: %w[m], desc: "Mandatory argument"
     argument :optional_arg, aliases: %w[o],
-                            desc: "Optional argument (has to have default value in call method)"
+      desc: "Optional argument (has to have default value in call method)"
     option :option_one, aliases: %w[1], desc: "Option one"
     option :boolean_option, aliases: %w[b], desc: "Option boolean", type: :boolean
     option :option_with_default, aliases: %w[d], desc: "Option default", default: "test"

--- a/spec/support/fixtures/inline
+++ b/spec/support/fixtures/inline
@@ -8,7 +8,7 @@ require_relative "../../../lib/dry/cli/inline"
 desc "Baz command line interface"
 argument :mandatory_arg, required: true, aliases: %w[m], desc: "Mandatory argument"
 argument :optional_arg, aliases: %w[o],
-                        desc: "Optional argument (has to have default value in call method)"
+  desc: "Optional argument (has to have default value in call method)"
 option :option_one, aliases: %w[1], desc: "Option one"
 option :boolean_option, aliases: %w[b], desc: "Option boolean", type: :boolean
 option :option_with_default, aliases: %w[d], desc: "Option default", default: "test"

--- a/spec/unit/dry/cli/cli_spec.rb
+++ b/spec/unit/dry/cli/cli_spec.rb
@@ -202,4 +202,44 @@ RSpec.describe "CLI" do
       end
     end
   end
+
+  context "IO streams" do
+    it "uses custom stdout for help output" do
+      registry = Module.new do
+        extend Dry::CLI::Registry
+        register "foo", Class.new(Dry::CLI::Command) { desc "A foo command"; def call(*); end }
+      end
+      cli = Dry::CLI.new(registry)
+
+      io = StringIO.new
+      expect { cli.call(arguments: ["foo", "--help"], stdout: io) }.to raise_error(SystemExit)
+      expect(io.string).to include("A foo command")
+    end
+
+    it "uses custom stderr for error output" do
+      registry = Module.new do
+        extend Dry::CLI::Registry
+        register "foo", Class.new(Dry::CLI::Command) { desc "A foo command"; def call(*); end }
+      end
+      cli = Dry::CLI.new(registry)
+
+      io = StringIO.new
+      expect { cli.call(arguments: ["foo", "--unknown"], stderr: io) }.to raise_error(SystemExit)
+      expect(io.string).to eq("ERROR: \"rspec foo\" was called with arguments \"--unknown\"\n")
+    end
+
+    it "passes stdin to command and writes to custom stdout" do
+      command_class = Class.new(Dry::CLI::Command) do
+        def call(**)
+          stdout.puts stdin.gets
+        end
+      end
+      cli = Dry.CLI(command_class)
+
+      input = StringIO.new("hello\n")
+      output = StringIO.new
+      cli.call(arguments: [], stdin: input, stdout: output)
+      expect(output.string).to eq("hello\n")
+    end
+  end
 end

--- a/spec/unit/dry/cli/cli_spec.rb
+++ b/spec/unit/dry/cli/cli_spec.rb
@@ -201,45 +201,5 @@ RSpec.describe "CLI" do
         )
       end
     end
-
-    it "exposes @out and @err to command without overriding pre-existing ivars" do
-      # @out and @err are exposed by default
-      command_class = Class.new(Dry::CLI::Command) do
-        def call(**)
-          @out.puts "out"
-          @err.puts "err"
-        end
-      end
-      cli = Dry.CLI(command_class.new)
-
-      default_out = StringIO.new
-      default_err = StringIO.new
-      cli.call(arguments: [], out: default_out, err: default_err)
-
-      expect(default_out.string).to eq("out\n")
-      expect(default_err.string).to eq("err\n")
-
-      # @out and @err do not override pre-existing ivars
-      custom_command_class = Class.new(command_class) do
-        define_method(:initialize) do |out, err|
-          super()
-          @out = out
-          @err = err
-        end
-      end
-
-      custom_out = StringIO.new
-      custom_err = StringIO.new
-      cli = Dry.CLI(custom_command_class.new(custom_out, custom_err))
-
-      default_out = StringIO.new
-      default_err = StringIO.new
-      cli.call(arguments: [], out: default_out, err: default_err)
-
-      expect(custom_out.string).to eq("out\n")
-      expect(custom_err.string).to eq("err\n")
-      expect(default_out.string).to eq("")
-      expect(default_err.string).to eq("")
-    end
   end
 end


### PR DESCRIPTION
Introduce `stderr`, `stdin`, and `stdout` streams to `Dry::CLI` and its components to better handle I/O. This allows commands to utilize specific input/output streams, improving flexibility and testability. Refactor existing methods to use the new stream parameters consistently.

As an alternative to #150

cc @timriley