### PR TITLE
Fix missing optional arguments to win over values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,21 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
       # ...
     ]
   end
+  
+- As with options, optional arguments can now be omitted even if list of acceptable values is defined. (@svoop in #155)
+
+  ```ruby
+  argument :required_arg, required: true, values: %w(one two)
+  argument :optional_arg, required: false, values: %w(one two)
+  ```
+
+  ```
+  cmd             # ERROR
+  cmd one         # OKAY
+  cmd three       # ERROR 
+  cmd one two     # OKAY
+  cmd one three   # ERROR
+  ```
 
 ### Deprecated
 

--- a/lib/dry/cli/option.rb
+++ b/lib/dry/cli/option.rb
@@ -130,6 +130,8 @@ module Dry
 
       # @api private
       def valid_value?(value)
+        return true if value.nil? && !required?
+
         available_values = values
         return true if available_values.nil?
 

--- a/spec/support/fixtures/shared_commands.rb
+++ b/spec/support/fixtures/shared_commands.rb
@@ -82,6 +82,17 @@ module Commands
         puts steps
       end
     end
+
+    class Vacuum < Dry::CLI::Command
+      desc "Vacuum the database"
+
+      argument :mode, desc: "Optional mode of vacuum", required: true, values: [:full, :freeze, :verbose]
+      argument :parallel, desc: "Parallel workers", values: [1, 2, 3]
+
+      def call(mode:, parallel: nil, **)
+        puts "mode: #{mode}, parallel: #{parallel}"
+      end
+    end
   end
 
   module Destroy

--- a/spec/support/fixtures/with_block.rb
+++ b/spec/support/fixtures/with_block.rb
@@ -37,14 +37,15 @@ WithBlock = Dry::CLI.new do |cli|
   cli.register "callbacks",        Webpack::CLI::CallbacksCommand
 
   cli.register "db" do |prefix|
-    prefix.register "apply",   Commands::DB::Apply
-    prefix.register "console", Commands::DB::Console
-    prefix.register "create",  Commands::DB::Create
-    prefix.register "drop",    Commands::DB::Drop
-    prefix.register "migrate", Commands::DB::Migrate
-    prefix.register "prepare", Commands::DB::Prepare
-    prefix.register "version", Commands::DB::Version
+    prefix.register "apply",    Commands::DB::Apply
+    prefix.register "console",  Commands::DB::Console
+    prefix.register "create",   Commands::DB::Create
+    prefix.register "drop",     Commands::DB::Drop
+    prefix.register "migrate",  Commands::DB::Migrate
+    prefix.register "prepare",  Commands::DB::Prepare
+    prefix.register "version",  Commands::DB::Version
     prefix.register "rollback", Commands::DB::Rollback
+    prefix.register "vacuum",   Commands::DB::Vacuum
   end
 
   cli.register "destroy", aliases: ["d"] do |prefix|

--- a/spec/support/fixtures/with_registry.rb
+++ b/spec/support/fixtures/with_registry.rb
@@ -12,14 +12,15 @@ module Foo
       register "assets precompile", ::Commands::Assets::Precompile
       register "console",           ::Commands::Console
       register "db" do |prefix|
-        prefix.register "apply",   ::Commands::DB::Apply
-        prefix.register "console", ::Commands::DB::Console
-        prefix.register "create",  ::Commands::DB::Create
-        prefix.register "drop",    ::Commands::DB::Drop
-        prefix.register "migrate", ::Commands::DB::Migrate
-        prefix.register "prepare", ::Commands::DB::Prepare
-        prefix.register "version", ::Commands::DB::Version
+        prefix.register "apply",    ::Commands::DB::Apply
+        prefix.register "console",  ::Commands::DB::Console
+        prefix.register "create",   ::Commands::DB::Create
+        prefix.register "drop",     ::Commands::DB::Drop
+        prefix.register "migrate",  ::Commands::DB::Migrate
+        prefix.register "prepare",  ::Commands::DB::Prepare
+        prefix.register "version",  ::Commands::DB::Version
         prefix.register "rollback", ::Commands::DB::Rollback
+        prefix.register "vacuum",   ::Commands::DB::Vacuum
       end
 
       register "destroy", aliases: ["d"] do |prefix|

--- a/spec/support/fixtures/with_zero_arity_block.rb
+++ b/spec/support/fixtures/with_zero_arity_block.rb
@@ -39,14 +39,15 @@ WithZeroArityBlock = Dry.CLI do
   register "callbacks",        Webpack::CLI::CallbacksCommand
 
   register "db" do
-    register "apply",   Commands::DB::Apply
-    register "console", Commands::DB::Console
-    register "create",  Commands::DB::Create
-    register "drop",    Commands::DB::Drop
-    register "migrate", Commands::DB::Migrate
-    register "prepare", Commands::DB::Prepare
-    register "version", Commands::DB::Version
+    register "apply",    Commands::DB::Apply
+    register "console",  Commands::DB::Console
+    register "create",   Commands::DB::Create
+    register "drop",     Commands::DB::Drop
+    register "migrate",  Commands::DB::Migrate
+    register "prepare",  Commands::DB::Prepare
+    register "version",  Commands::DB::Version
     register "rollback", Commands::DB::Rollback
+    register "vacuum",   Commands::DB::Vacuum
   end
 
   register "destroy", aliases: ["d"] do

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -156,7 +156,7 @@ RSpec.shared_examples "Commands" do |cli|
         expect(output).to eq("exec - Task: test - Directories: []\n")
       end
 
-      it "capture all the remaining arguments" do
+      it "captures all the remaining arguments" do
         output = capture_output { cli.call(arguments: %w[exec test api admin]) }
         expect(output).to eq("exec - Task: test - Directories: [\"api\", \"admin\"]\n")
       end
@@ -164,7 +164,7 @@ RSpec.shared_examples "Commands" do |cli|
 
     context "with supported values" do
       context "and with supported value passed" do
-        it "call the command with the option" do
+        it "calls the command with the option" do
           output = capture_output { cli.call(arguments: %w[console --engine=pry]) }
           expect(output).to eq("console - engine: pry\n")
         end
@@ -181,6 +181,20 @@ RSpec.shared_examples "Commands" do |cli|
         it "prints error" do
           error = capture_error { cli.call(arguments: %w[db rollback 4]) }
           expect(error).to eq("ERROR: \"rspec db rollback\" was called with arguments \"4\"\n")
+        end
+      end
+
+      context "without a required argument limited by values array" do
+        it "prints error" do
+          error = capture_error { cli.call(arguments: %w[db vacuum]) }
+          expect(error).to eq("ERROR: \"rspec db vacuum\" was called with arguments \"\"\n")
+        end
+      end
+
+      context "without an optional argument limited by values array" do
+        it "can be used" do
+          output = capture_output { cli.call(arguments: %w[db vacuum full]) }
+          expect(output).to eq("mode: full, parallel: \n")
         end
       end
     end

--- a/spec/unit/dry/cli/cli_spec.rb
+++ b/spec/unit/dry/cli/cli_spec.rb
@@ -27,6 +27,24 @@ RSpec.describe "CLI" do
     end
   end
 
+  context "optional argument with required values" do
+    let(:cli) do
+      Class.new(Dry::CLI::Command) do
+        argument :first, required: true, values: %w[one two]
+        argument :second, required: false, values: %w[one two]
+
+        def call(first:, second: nil)
+          puts "first: #{first}, second: #{second}"
+        end
+      end.then { Dry.CLI(_1) }
+    end
+
+    it "does not fail when optional argument is missing" do
+      result = capture_output { cli.call(arguments: ["one"]) }
+      expect(result).to eq("first: one, second: \n")
+    end
+  end
+
   context "with command" do
     let(:cli) { Dry.CLI(Baz::CLI) }
     let(:cmd) { File.basename($PROGRAM_NAME, File.extname($PROGRAM_NAME)) }


### PR DESCRIPTION
See https://github.com/dry-rb/dry-cli/issues/126#issuecomment-3806588273

Optional arguments (either implic or with explicit `required: false`) should be accepted when missing even if a `values` list does not include `nil` as a value – at least as per the principle of least surprise. 

```ruby
argument :required_arg, required: true, values: %w(one two)
argument :optional_arg, required: false, values: %w(one two)
```

```
cmd             # ERROR
cmd one         # OKAY
cmd three       # ERROR 
cmd one two     # OKAY
cmd one three   # ERROR
```

Not sure how best to spec this, hope it's okay to having added a vacuum subcommand to the db example.

/cc @gustavothecoder 
