### PR TITLE
Slightly better errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
   cmd one three   # ERROR
   ```
 
+- Improved error messages to be more precise and helpful (@katafrakt in #158)
+
 ### Deprecated
 
 ### Removed

--- a/lib/dry/cli/errors.rb
+++ b/lib/dry/cli/errors.rb
@@ -11,6 +11,24 @@ module Dry
 
     # @since 1.4.0
     class ValueError < Error
+      attr_reader :value, :argument
+
+      def initialize(value: nil, argument: nil)
+        @value = value
+        @argument = argument
+        super
+      end
+
+      def message
+        if @value.nil? && @argument
+          "ERROR: \"#{@argument.name}\" is required"
+        elsif @argument
+          accepted = @argument.values
+          "ERROR: invalid argument \"#{@value}\" for \"#{@argument.name}\"; accepted values: #{accepted.join(', ')}"
+        else
+          "ERROR: invalid argument \"#{@value}\""
+        end
+      end
     end
 
     # @since NEXT

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -33,8 +33,8 @@ module Dry
         parse_required_params(command, arguments, prog_name, parsed_options)
       rescue ::OptionParser::ParseError => exception
         Result.failure("ERROR: \"#{prog_name}\" was called with #{exception.reason} \"#{exception.args.join(" ")}\"")
-      rescue ValueError
-        Result.failure("ERROR: \"#{prog_name}\" was called with arguments \"#{original_arguments.join(" ")}\"")
+      rescue ValueError => exception
+        Result.failure(exception.message)
       rescue CastError => exception
         Result.failure(exception.message)
       end
@@ -80,13 +80,13 @@ module Dry
         command_arguments.each_with_index do |cmd_arg, index|
           if cmd_arg.array?
             arg = arguments[index..] || default_values[cmd_arg.name]
-            raise ValueError unless cmd_arg.valid_value?(arg)
+            raise ValueError.new(value: arg, argument: cmd_arg) unless cmd_arg.valid_value?(arg)
 
             result[cmd_arg.name] = arg
             break
           else
             value = arguments.at(index) || default_values[cmd_arg.name]
-            raise ValueError unless cmd_arg.valid_value?(value)
+            raise ValueError.new(value: value, argument: cmd_arg) unless cmd_arg.valid_value?(value)
 
             result[cmd_arg.name] = cmd_arg.cast(value)
           end

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -14,7 +14,6 @@ module Dry
       # @api private
       #
       def self.call(command, arguments, prog_name)
-        original_arguments = arguments.dup
         parsed_options = {}
 
         OptionParser.new do |opts|

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -31,7 +31,9 @@ module Dry
 
         parsed_options = command.default_params.merge(parsed_options)
         parse_required_params(command, arguments, prog_name, parsed_options)
-      rescue ::OptionParser::ParseError, ValueError
+      rescue ::OptionParser::ParseError => exception
+        Result.failure("ERROR: \"#{prog_name}\" was called with #{exception.reason} \"#{exception.args.join(" ")}\"")
+      rescue ValueError
         Result.failure("ERROR: \"#{prog_name}\" was called with arguments \"#{original_arguments.join(" ")}\"")
       rescue CastError => exception
         Result.failure(exception.message)

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -111,7 +111,7 @@ RSpec.shared_examples "Commands" do |cli|
 
     it "a param with unknown param" do
       error = capture_error { cli.call(arguments: %w[server --unknown 1234]) }
-      expect(error).to eq("ERROR: \"rspec server\" was called with arguments \"--unknown 1234\"\n")
+      expect(error).to eq("ERROR: \"rspec server\" was called with invalid option \"--unknown\"\n")
     end
 
     it "with boolean param" do
@@ -173,7 +173,7 @@ RSpec.shared_examples "Commands" do |cli|
       context "and with an unknown value passed" do
         it "prints error" do
           error = capture_error { cli.call(arguments: %w[console --engine=unknown]) }
-          expect(error).to eq("ERROR: \"rspec console\" was called with arguments \"--engine=unknown\"\n")
+          expect(error).to eq("ERROR: \"rspec console\" was called with invalid argument \"--engine=unknown\"\n")
         end
       end
 
@@ -243,7 +243,7 @@ RSpec.shared_examples "Commands" do |cli|
 
       it "with unknown param" do
         error = capture_error { cli.call(arguments: %w[new bookshelf --unknown 1234]) }
-        expect(error).to eq("ERROR: \"rspec new\" was called with arguments \"bookshelf --unknown 1234\"\n")
+        expect(error).to eq("ERROR: \"rspec new\" was called with invalid option \"--unknown\"\n")
       end
 
       it "no required" do

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -180,14 +180,14 @@ RSpec.shared_examples "Commands" do |cli|
       context "with an unknown argument" do
         it "prints error" do
           error = capture_error { cli.call(arguments: %w[db rollback 4]) }
-          expect(error).to eq("ERROR: \"rspec db rollback\" was called with arguments \"4\"\n")
+          expect(error).to eq("ERROR: invalid argument \"4\" for \"steps\"; accepted values: 1, 2, 3\n")
         end
       end
 
       context "without a required argument limited by values array" do
         it "prints error" do
           error = capture_error { cli.call(arguments: %w[db vacuum]) }
-          expect(error).to eq("ERROR: \"rspec db vacuum\" was called with arguments \"\"\n")
+          expect(error).to eq("ERROR: \"mode\" is required\n")
         end
       end
 

--- a/spec/unit/dry/cli/cli_spec.rb
+++ b/spec/unit/dry/cli/cli_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe "CLI" do
 
       io = StringIO.new
       expect { cli.call(arguments: ["foo", "--unknown"], stderr: io) }.to raise_error(SystemExit)
-      expect(io.string).to eq("ERROR: \"rspec foo\" was called with arguments \"--unknown\"\n")
+      expect(io.string).to eq("ERROR: \"rspec foo\" was called with invalid option \"--unknown\"\n")
     end
 
     it "passes stdin to command and writes to custom stdout" do


### PR DESCRIPTION
As we want to release 2.0, I think it will be good to improve error messages at least a bit. Right now it's quite rudimentary - no matter what happens, it prints the command name and all the args that were passed to it. This is not very useful, as I know what arguments were passed (I just typed them). Instead, let's surface the error from `OptionParser`, which points to a particular invalid argument or option.

## Example

**Now:**

```
ERROR: "cli.rb g test" was called with arguments "--framework rails --mode strict"
ERROR: "cli.rb g test" was called with arguments "--framework rspec --mode strict"
```

**After:**

```
ERROR: "cli.rb g test" was called with invalid argument "--framework rails"
ERROR: "cli.rb g test" was called with invalid option "--mode"
```

Not sure about `ERROR` prefix - #101 suggests to drop it.

Any other suggestions for improvement are welcome.