### PR TITLE
Add support for repeatable array options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 - Support for command namespaces (@gustavothecoder in #135)
 - New `:cast` option for options and arguments, allowing to leverage Dry Types or simple procs/lambdas to cast values from string to some other type of value (@katafrakt in #157)
+- Array options can be supplied by repeated flags. (@Drowze in #159)
+
+    The following are now equivalent:
+    ```
+    my-cli --array-flag foo,bar
+    my-cli --array-flag foo --array-flag bar
+    ```
 
 ### Changed
 

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -22,7 +22,14 @@ module Dry
             opts.on(*option.parser_options) do |value|
               raise ValueError.new(value: value, argument: option) unless option.valid_value?(value)
 
-              parsed_options[option.name.to_sym] = option.cast(value)
+              option_name = option.name.to_sym
+              value = option.cast(value)
+              if option.array?
+                parsed_options[option_name] ||= []
+                parsed_options[option_name] += value
+              else
+                parsed_options[option_name] = value
+              end
             end
           end
 

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -23,12 +23,11 @@ module Dry
               raise ValueError.new(value: value, argument: option) unless option.valid_value?(value)
 
               option_name = option.name.to_sym
-              value = option.cast(value)
               if option.array?
                 parsed_options[option_name] ||= []
-                parsed_options[option_name] += value
+                parsed_options[option_name] += option.cast(value)
               else
-                parsed_options[option_name] = value
+                parsed_options[option_name] = option.cast(value)
               end
             end
           end

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -160,6 +160,16 @@ RSpec.shared_examples "Commands" do |cli|
         output = capture_output { cli.call(arguments: %w[exec test api admin]) }
         expect(output).to eq("exec - Task: test - Directories: [\"api\", \"admin\"]\n")
       end
+
+      it "captures repeated array options" do
+        output = capture_output { cli.call(arguments: %w[server --deps=dep42 --deps=dep43]) }
+
+        if RUBY_VERSION < "3.4"
+          expect(output).to eq("server - {:code_reloading=>true, :deps=>[\"dep42\", \"dep43\"]}\n")
+        else
+          expect(output).to eq("server - {code_reloading: true, deps: [\"dep42\", \"dep43\"]}\n")
+        end
+      end
     end
 
     context "with supported values" do


### PR DESCRIPTION
Support repeatable :array options (in addition to comma-separated)

E.g.:
```ruby
# Given that `my_app` has `api` command taking a `--header` array option
# $ my_app api /some/path \
#     --header 'content-type: application-json' \
#     --header 'accept: application/json'

# Before:
options[:header] # => ["accept: application/json"]

# After:
options[:header] # => ["content-type: application-json", "accept: application/json"]
```

---

Related:
- https://github.com/dry-rb/dry-cli/pull/157#issuecomment-4925608782
- https://github.com/dry-rb/dry-cli/issues/129#issuecomment-4926140636