### PR TITLE
Add `long_desc` and split `-h` from `--help`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 - Support for command namespaces (@gustavothecoder in #135)
 - New `:cast` option for options and arguments, allowing to leverage Dry Types or simple procs/lambdas to cast values from string to some other type of value (@katafrakt in #157)
+- `long_desc` method for a long command description. This will show when `--help` is given, whereas `-h` will show the short description. When no long description is provided, both `--help` and `-h` show the short description. (@aaronmallen in #160)
 
 ### Changed
 

--- a/lib/dry/cli.rb
+++ b/lib/dry/cli.rb
@@ -167,7 +167,7 @@ module Dry
 
       result = Parser.call(command, arguments, prog_name)
 
-      return help(command, prog_name) if result.help?
+      return help(command, prog_name, long: result.long_help?) if result.help?
 
       return error(result) if result.error?
 
@@ -185,8 +185,8 @@ module Dry
 
     # @since 0.6.0
     # @api private
-    def help(command, prog_name)
-      stdout.puts Banner.call(command, prog_name)
+    def help(command, prog_name, long: false)
+      stdout.puts Banner.call(command, prog_name, long: long)
       exit(0) # Successful exit
     end
 

--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -93,12 +93,7 @@ module Dry
       #
       # @api private
       def self.command_description(command, long = false)
-        description =
-          if long
-            command.long_description || command.description
-          else
-            command.description
-          end
+        description = (command.long_description if long) || command.description
         return if description.nil?
 
         body = description.chomp.lines.map { |line|

--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -88,9 +88,8 @@ module Dry
 
       # Renders the "Description" section.
       #
-      # The long description is only shown on full help (`--help`), falling
-      # back to the short description when it is not set. Short help (`-h`)
-      # always shows the short description.
+      # The long description is only shown on full help (`--help`), falling back to the short
+      # description when it is not set. Short help (`-h`) always shows the short description.
       #
       # @api private
       def self.command_description(command, long = false)

--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -21,19 +21,19 @@ module Dry
       # @param out [IO] standard output
       #
       # @api private
-      def self.call(command, name)
+      def self.call(command, name, long: false)
         banner_lines =
           if CLI.command?(command)
-            command_banner(command, name)
+            command_banner(command, name, long)
           else
-            namespace_banner(command, name)
+            namespace_banner(command, name, long)
           end
 
         banner_lines.compact.join("\n")
       end
 
       # @api private
-      def self.command_banner(command, name)
+      def self.command_banner(command, name, long = false)
         argument_entries = command_argument_entries(command)
         example_entries = command_example_entries(command, name)
         option_entries = command_option_entries(command)
@@ -42,7 +42,7 @@ module Dry
         [
           command_name(name),
           command_name_and_arguments(command, name),
-          command_description(command),
+          command_description(command, long),
           command_subcommands(command),
           section("Arguments", argument_entries, indent),
           section("Options", option_entries, indent),
@@ -52,14 +52,14 @@ module Dry
 
       # @since 1.1.1
       # @api private
-      def self.namespace_banner(namespace, name)
+      def self.namespace_banner(namespace, name, long = false)
         option_entries = command_option_entries(namespace)
         indent = capture_indent(option_entries)
 
         [
           command_name(name, "Namespace"),
           command_name_and_arguments(namespace, name),
-          command_description(namespace),
+          command_description(namespace, long),
           command_subcommands(namespace),
           section("Options", option_entries, indent)
         ]
@@ -86,11 +86,27 @@ module Dry
         "\n#{heading}:\n#{entries.map { |entry| entry.render(indent) }.join("\n")}"
       end
 
+      # Renders the "Description" section.
+      #
+      # The long description is only shown on full help (`--help`), falling
+      # back to the short description when it is not set. Short help (`-h`)
+      # always shows the short description.
+      #
       # @api private
-      def self.command_description(command)
-        return if command.description.nil?
+      def self.command_description(command, long = false)
+        description =
+          if long
+            command.long_description || command.description
+          else
+            command.description
+          end
+        return if description.nil?
 
-        "\nDescription:\n  #{command.description}"
+        body = description.chomp.lines.map { |line|
+          line.strip.empty? ? "" : "  #{line.rstrip}"
+        }.join("\n")
+
+        "\nDescription:\n#{body}"
       end
 
       def self.command_subcommands(command)

--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -14,10 +14,11 @@ module Dry
       def self.inherited(base)
         super
         base.class_eval do
-          @_mutex       = Mutex.new
-          @description  = nil
-          @examples     = []
-          @subcommands  = []
+          @_mutex           = Mutex.new
+          @description      = nil
+          @long_description = nil
+          @examples         = []
+          @subcommands      = []
           @arguments = base.superclass_arguments || []
           @options = base.superclass_options || []
         end
@@ -30,6 +31,10 @@ module Dry
         # @since 0.1.0
         # @api private
         attr_reader :description
+
+        # @since unreleased
+        # @api private
+        attr_reader :long_description
 
         # @since 0.1.0
         # @api private
@@ -66,6 +71,36 @@ module Dry
       #   end
       def self.desc(description)
         @description = description
+      end
+
+      # Set the long description of the command
+      #
+      # It is printed in the "Description" section of the full command help
+      # (`--help`). Short help (`-h`) and command listings keep using the
+      # short description set via `.desc`. When no long description is set,
+      # `--help` falls back to the short description.
+      #
+      # @param long_description [String] the long description
+      #
+      # @since unreleased
+      #
+      # @example
+      #   require "dry/cli"
+      #
+      #   class Echo < Dry::CLI::Command
+      #     desc "Prints given input"
+      #     long_desc <<~DESC
+      #       Prints the given input back to standard output.
+      #
+      #       When no input is given, it prints an empty line.
+      #     DESC
+      #
+      #     def call(*)
+      #       # ...
+      #     end
+      #   end
+      def self.long_desc(long_description)
+        @long_description = long_description
       end
 
       # Describe the usage of the command
@@ -411,6 +446,7 @@ module Dry
 
       delegate %i[
         description
+        long_description
         examples
         arguments
         options

--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -32,7 +32,6 @@ module Dry
         # @api private
         attr_reader :description
 
-        # @since unreleased
         # @api private
         attr_reader :long_description
 
@@ -57,8 +56,6 @@ module Dry
       #
       # @param description [String] the description
       #
-      # @since 0.1.0
-      #
       # @example
       #   require "dry/cli"
       #
@@ -69,6 +66,9 @@ module Dry
       #       # ...
       #     end
       #   end
+      #
+      # @api public
+      # @since 0.1.0
       def self.desc(description)
         @description = description
       end
@@ -81,8 +81,6 @@ module Dry
       # `--help` falls back to the short description.
       #
       # @param long_description [String] the long description
-      #
-      # @since unreleased
       #
       # @example
       #   require "dry/cli"
@@ -99,6 +97,9 @@ module Dry
       #       # ...
       #     end
       #   end
+      #
+      # @api public
+      # @since unreleased
       def self.long_desc(long_description)
         @long_description = long_description
       end
@@ -434,7 +435,6 @@ module Dry
         superclass_variable_dup(:@options)
       end
 
-      # @since unreleased
       # @api private
       def initialize(stderr: $stderr, stdin: $stdin, stdout: $stdout)
         @stderr = stderr

--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -75,10 +75,9 @@ module Dry
 
       # Set the long description of the command
       #
-      # It is printed in the "Description" section of the full command help
-      # (`--help`). Short help (`-h`) and command listings keep using the
-      # short description set via `.desc`. When no long description is set,
-      # `--help` falls back to the short description.
+      # It is printed in the "Description" section of the full command help (`--help`). Short help
+      # (`-h`) and command listings keep using the short description set via `.desc`. When no long
+      # description is set, `--help` falls back to the short description.
       #
       # @param long_description [String] the long description
       #

--- a/lib/dry/cli/namespace.rb
+++ b/lib/dry/cli/namespace.rb
@@ -28,7 +28,6 @@ module Dry
         # @api private
         attr_reader :description
 
-        # @since unreleased
         # @api private
         attr_reader :long_description
 
@@ -53,8 +52,6 @@ module Dry
       #
       # @param description [String] the description
       #
-      # @since 1.1.1
-      #
       # @example
       #   require "dry/cli"
       #
@@ -65,6 +62,9 @@ module Dry
       #       # ...
       #     end
       #   end
+      #
+      # @api public
+      # @since 1.1.1
       def self.desc(description)
         @description = description
       end
@@ -77,8 +77,6 @@ module Dry
       # `--help` falls back to the short description.
       #
       # @param long_description [String] the long description
-      #
-      # @since unreleased
       #
       # @example
       #   require "dry/cli"
@@ -94,6 +92,9 @@ module Dry
       #       # ...
       #     end
       #   end
+      #
+      # @api public
+      # @since unreleased
       def self.long_desc(long_description)
         @long_description = long_description
       end

--- a/lib/dry/cli/namespace.rb
+++ b/lib/dry/cli/namespace.rb
@@ -11,11 +11,12 @@ module Dry
       def self.inherited(base)
         super
         base.class_eval do
-          @description  = nil
-          @examples     = []
-          @arguments    = []
-          @options      = []
-          @subcommands  = []
+          @description      = nil
+          @long_description = nil
+          @examples         = []
+          @arguments        = []
+          @options          = []
+          @subcommands      = []
         end
         base.extend ClassMethods
       end
@@ -26,6 +27,10 @@ module Dry
         # @since 1.1.1
         # @api private
         attr_reader :description
+
+        # @since unreleased
+        # @api private
+        attr_reader :long_description
 
         # @since 1.1.1
         # @api private
@@ -62,6 +67,35 @@ module Dry
       #   end
       def self.desc(description)
         @description = description
+      end
+
+      # Set the long description of the namespace
+      #
+      # It is printed in the "Description" section of the full namespace help
+      # (`--help`). Short help (`-h`) and command listings keep using the
+      # short description set via `.desc`. When no long description is set,
+      # `--help` falls back to the short description.
+      #
+      # @param long_description [String] the long description
+      #
+      # @since unreleased
+      #
+      # @example
+      #   require "dry/cli"
+      #
+      #   class YourNamespace < Dry::CLI::Namespace
+      #     desc "Collection of really useful commands"
+      #     long_desc <<~DESC
+      #       A longer, multi-line explanation of what the commands in
+      #       this namespace do and how they relate to each other.
+      #     DESC
+      #
+      #     class YourCommand < Dry::CLI::Command
+      #       # ...
+      #     end
+      #   end
+      def self.long_desc(long_description)
+        @long_description = long_description
       end
 
       # @since 1.1.1

--- a/lib/dry/cli/namespace.rb
+++ b/lib/dry/cli/namespace.rb
@@ -71,10 +71,9 @@ module Dry
 
       # Set the long description of the namespace
       #
-      # It is printed in the "Description" section of the full namespace help
-      # (`--help`). Short help (`-h`) and command listings keep using the
-      # short description set via `.desc`. When no long description is set,
-      # `--help` falls back to the short description.
+      # It is printed in the "Description" section of the full namespace help (`--help`). Short help
+      # (`-h`) and command listings keep using the short description set via `.desc`. When no long
+      # description is set, `--help` falls back to the short description.
       #
       # @param long_description [String] the long description
       #

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -13,6 +13,7 @@ module Dry
       # @since 0.1.0
       # @api private
       #
+      # rubocop:disable Metrics/AbcSize
       def self.call(command, arguments, prog_name)
         parsed_options = {}
 
@@ -23,8 +24,12 @@ module Dry
             end
           end
 
-          opts.on_tail("-h", "--help") do
+          opts.on_tail("-h") do
             return Result.help
+          end
+
+          opts.on_tail("--help") do
+            return Result.help(long: true)
           end
         end.parse!(arguments)
 
@@ -37,6 +42,7 @@ module Dry
       rescue CastError => exception
         Result.failure(exception.message)
       end
+      # rubocop:enable Metrics/AbcSize
 
       # @since 0.1.0
       # @api private
@@ -99,8 +105,8 @@ module Dry
       class Result
         # @since 0.1.0
         # @api private
-        def self.help
-          new(help: true)
+        def self.help(long: false)
+          new(help: true, long_help: long)
         end
 
         # @since 0.1.0
@@ -125,10 +131,11 @@ module Dry
 
         # @since 0.1.0
         # @api private
-        def initialize(arguments: {}, error: nil, help: false)
+        def initialize(arguments: {}, error: nil, help: false, long_help: false)
           @arguments = arguments
           @error     = error
           @help      = help
+          @long_help = long_help
         end
 
         # @since 0.1.0
@@ -141,6 +148,12 @@ module Dry
         # @api private
         def help?
           @help
+        end
+
+        # @since unreleased
+        # @api private
+        def long_help?
+          @long_help
         end
       end
     end

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -150,7 +150,6 @@ module Dry
           @help
         end
 
-        # @since unreleased
         # @api private
         def long_help?
           @long_help

--- a/spec/unit/dry/cli/command_spec.rb
+++ b/spec/unit/dry/cli/command_spec.rb
@@ -16,6 +16,20 @@ RSpec.describe "Command" do
     end
   end
 
+  describe "long description definition" do
+    class CommandWithLongDesc < Dry::CLI::Command
+      desc "Short description"
+      long_desc "A much longer description of what this command does"
+    end
+
+    it "stores the long description separately from the short one" do
+      expect(CommandWithLongDesc.description).to eq("Short description")
+      expect(CommandWithLongDesc.long_description).to eq(
+        "A much longer description of what this command does"
+      )
+    end
+  end
+
   describe "argument definition" do
     class CommandWithDuplicateArgs < Dry::CLI::Command
       argument :version, desc: "1"

--- a/spec/unit/dry/cli/long_description_spec.rb
+++ b/spec/unit/dry/cli/long_description_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+RSpec.describe "Long description" do
+  let(:cmd) { File.basename($PROGRAM_NAME, File.extname($PROGRAM_NAME)) }
+
+  let(:echo) do
+    Class.new(Dry::CLI::Command) do
+      desc "Prints given input"
+      long_desc <<~DESC
+        Prints the given input back to standard output.
+
+        When no input is given, it prints an empty line.
+      DESC
+
+      def call(*); end
+    end
+  end
+
+  let(:short_only) do
+    Class.new(Dry::CLI::Command) do
+      desc "Only has a short description"
+
+      def call(*); end
+    end
+  end
+
+  let(:cli) do
+    commands = {echo: echo, short_only: short_only}
+
+    Dry.CLI do |c|
+      c.register "echo", commands[:echo]
+      c.register "short", commands[:short_only]
+    end
+  end
+
+  it "prints the long description when calling --help" do
+    output = capture_output { cli.call(arguments: %w[echo --help]) }
+
+    expected = <<~OUTPUT
+      Command:
+        #{cmd} echo
+
+      Usage:
+        #{cmd} echo
+
+      Description:
+        Prints the given input back to standard output.
+
+        When no input is given, it prints an empty line.
+
+      Options:
+        --help, -h  # Print this help
+    OUTPUT
+    expect(output).to eq(expected)
+  end
+
+  it "prints the short description when calling -h" do
+    output = capture_output { cli.call(arguments: %w[echo -h]) }
+
+    expected = <<~OUTPUT
+      Command:
+        #{cmd} echo
+
+      Usage:
+        #{cmd} echo
+
+      Description:
+        Prints given input
+
+      Options:
+        --help, -h  # Print this help
+    OUTPUT
+    expect(output).to eq(expected)
+  end
+
+  it "falls back to the short description on --help when no long description is set" do
+    output = capture_output { cli.call(arguments: %w[short --help]) }
+
+    expected = <<~OUTPUT
+      Command:
+        #{cmd} short
+
+      Usage:
+        #{cmd} short
+
+      Description:
+        Only has a short description
+
+      Options:
+        --help, -h  # Print this help
+    OUTPUT
+    expect(output).to eq(expected)
+  end
+
+  context "with a namespace" do
+    let(:namespace) do
+      Class.new(Dry::CLI::Namespace) do
+        desc "Collection of useful commands"
+        long_desc <<~DESC
+          A longer explanation of what the commands in this
+          namespace do and how they relate to each other.
+        DESC
+      end
+    end
+
+    let(:sub) do
+      Class.new(Dry::CLI::Command) do
+        desc "Do the sub thing"
+
+        def call(*); end
+      end
+    end
+
+    let(:cli) do
+      commands = {namespace: namespace, sub: sub}
+
+      Dry.CLI do |c|
+        c.register "ns", commands[:namespace] do |prefix|
+          prefix.register "sub", commands[:sub]
+        end
+      end
+    end
+
+    it "prints the long description when calling --help" do
+      output = capture_output { cli.call(arguments: %w[ns --help]) }
+
+      expect(output).to include(<<~OUTPUT)
+        Description:
+          A longer explanation of what the commands in this
+          namespace do and how they relate to each other.
+      OUTPUT
+    end
+
+    it "prints the short description when calling -h" do
+      output = capture_output { cli.call(arguments: %w[ns -h]) }
+
+      expect(output).to include("Description:\n  Collection of useful commands")
+      expect(output).not_to include("A longer explanation")
+    end
+  end
+end


### PR DESCRIPTION
Commands and namespaces can now set a long description with `long_desc`. `-h` prints the
short description from `desc`; `--help` prints the long one. This mirrors how Clap treats
`about` and `long_about` in Rust.

```ruby
class Echo < Dry::CLI::Command
  desc "Prints given input"
  long_desc <<~DESC
    Prints the given input back to standard output.

    When no input is given, it prints an empty line.
  DESC
end
```

```sh
$ foo echo -h shows "Prints given input". $ foo echo --help shows the full text.
```

## How

- Command and Namespace gain a long_desc class method that stores @long_description.
- Parser registers -h and --help as separate handlers and marks the result when the
user asked for long help.
- Banner picks the description by help mode: long help uses long_description and falls
back to description; short help always uses description. Multi-line text now indents
under the Description: heading, and blank lines stay blank.
- Command listings still use the short desc.

## Compatibility

Commands without long_desc print the same output for both flags, so nothing changes for
existing CLIs.