### PR TITLE
Fix :array options combined with :values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,25 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 ### Fixed
 
 - Optional arguments were incorrectly displayed at the end of usage message (@gustavothecoder in #145)
+- Options combining `type: :array` with `values:` no longer return a single string instead of an array, and now accept comma-separated values. (@timriley in #161)
+
+  ```ruby
+  option :require, type: :array, values: %w[foo bar baz]
+  ```
+
+  ```
+  cmd --require=foo      # was "foo", now ["foo"]
+  cmd --require=foo,bar  # was an error, now ["foo", "bar"]
+  ```
+- Allow options and arguments to specify non-string `values:`, such as integers. These are cast to strings when declared, then compared against the strings given on the command line. (@timriley in #161)
+
+  ```ruby
+  option :level, values: [1, 2, 3]
+  ```
+
+  ```
+  cmd --level=1  # was an error, now "1"
+  ```
 
 ### Security
 

--- a/lib/dry/cli/option.rb
+++ b/lib/dry/cli/option.rb
@@ -15,11 +15,20 @@ module Dry
       # @api private
       attr_reader :options
 
+      # The accepted values, as strings.
+      #
+      # Values are given on the command line as strings, so they're normalized rather than compared
+      # across types. `options[:values]` keeps whatever was declared.
+      #
+      # @api private
+      attr_reader :values
+
       # @since 0.1.0
       # @api private
       def initialize(name, options = {})
         @name = name
         @options = options
+        @values = options[:values]&.map(&:to_s)
       end
 
       # @since 0.1.0
@@ -51,12 +60,6 @@ module Dry
       # @api private
       def cast_callable
         options[:cast]
-      end
-
-      # @since 0.1.0
-      # @api private
-      def values
-        options[:values]
       end
 
       # @since 0.1.0
@@ -97,9 +100,10 @@ module Dry
       # @since 0.1.0
       # @api private
       #
+      # rubocop:disable Metrics/PerceivedComplexity
       def parser_options
         dasherized_name = Inflector.dasherize(name)
-        parser_options  = []
+        parser_options = []
 
         if boolean?
           parser_options << "--[no-]#{dasherized_name}"
@@ -110,12 +114,20 @@ module Dry
           parser_options << "--#{dasherized_name} #{name}"
         end
 
-        parser_options << Array if array?
-        parser_options << values if values
+        if array?
+          # Array options can't also give `values` to OptionParser. This would match against the
+          # values array and return a single string member, skipping the `Array` conversion itself.
+          # {Parser} validates their values instead.
+          parser_options << Array
+        elsif values
+          parser_options << values
+        end
+
         parser_options.unshift(*alias_names) if aliases.any?
         parser_options << desc if desc
         parser_options
       end
+      # rubocop:enable Metrics/PerceivedComplexity
 
       # @since 0.1.0
       # @api private
@@ -131,28 +143,30 @@ module Dry
       # @api private
       def valid_value?(value)
         return true if value.nil? && !required?
-
-        available_values = values
-        return true if available_values.nil?
+        return true if values.nil?
 
         if array?
-          (value - available_values).empty?
+          value.all? { accepted_value?(_1) }
         else
-          available_values.map(&:to_s).include?(value.to_s)
+          accepted_value?(value)
         end
       end
 
       def cast(value)
         return value unless cast_callable.respond_to?(:call)
 
-        if type == :array
-          value.map { |el| cast_single(el) }
+        if array?
+          value.map { cast_single(_1) }
         else
           cast_single(value)
         end
       end
 
       private
+
+      def accepted_value?(value)
+        values.include?(value.to_s)
+      end
 
       def cast_single(value)
         cast_callable.call(value)

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -13,12 +13,15 @@ module Dry
       # @since 0.1.0
       # @api private
       #
+      # rubocop:disable Metrics/AbcSize
       def self.call(command, arguments, prog_name)
         parsed_options = {}
 
         OptionParser.new do |opts|
           command.options.each do |option|
             opts.on(*option.parser_options) do |value|
+              raise ValueError.new(value: value, argument: option) unless option.valid_value?(value)
+
               parsed_options[option.name.to_sym] = option.cast(value)
             end
           end
@@ -37,6 +40,7 @@ module Dry
       rescue CastError => exception
         Result.failure(exception.message)
       end
+      # rubocop:enable Metrics/AbcSize
 
       # @since 0.1.0
       # @api private

--- a/spec/support/fixtures/shared_commands.rb
+++ b/spec/support/fixtures/shared_commands.rb
@@ -17,12 +17,14 @@ module Commands
   class Console < Dry::CLI::Command
     desc "Starts Foo console"
     option :engine, desc: "Force a console engine", values: %w[irb pry ripl]
+    option :require, desc: "Libraries to require", type: :array, values: %w[foo bar baz]
 
     example "", "Uses the bundled engine"
     example "--engine=pry", "Force to use Pry"
 
-    def call(engine: nil, **)
+    def call(engine: nil, **options)
       puts "console - engine: #{engine}"
+      puts "console - require: #{options[:require].inspect}" if options.key?(:require)
     end
   end
 

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -177,6 +177,25 @@ RSpec.shared_examples "Commands" do |cli|
         end
       end
 
+      context "and the option is an array" do
+        it "returns an array for a single value" do
+          output = capture_output { cli.call(arguments: %w[console --require=foo]) }
+          expect(output).to eq("console - engine: \nconsole - require: [\"foo\"]\n")
+        end
+
+        it "returns an array for comma-separated values" do
+          output = capture_output { cli.call(arguments: %w[console --require=foo,bar]) }
+          expect(output).to eq("console - engine: \nconsole - require: [\"foo\", \"bar\"]\n")
+        end
+
+        it "prints error when one of the values is unsupported" do
+          error = capture_error { cli.call(arguments: %w[console --require=foo,unknown]) }
+          expect(error).to eq(
+            "ERROR: invalid argument \"[\"foo\", \"unknown\"]\" for \"require\"; accepted values: foo, bar, baz\n"
+          )
+        end
+      end
+
       context "with an unknown argument" do
         it "prints error" do
           error = capture_error { cli.call(arguments: %w[db rollback 4]) }


### PR DESCRIPTION
For `:array` options, `Option#parser_options` passed both `Array` (a type conversion) and `values` (a completion list) to `OptionParser#on`. These are mutually exclusive. When both are given, OptionParser matches against the completion list only and returns the matching string, skipping the array conversion. An array option declaring `values:` therefore produced a string rather than an array, and also rejected comma-separated values as an invalid argument.

For example, given this command:

```ruby
class Console < Dry::CLI::Command
  option :require, type: :array, values: %w[foo bar baz], desc: "Libraries to require"

  def call(**options)
    p options[:require]
  end
end
```

Before:

```
$ myapp console --require=foo
"foo"

$ myapp console --require=foo,bar
ERROR: "myapp console" was called with invalid argument "--require=foo,bar"

$ myapp console --require=foo,invalid
ERROR: "myapp console" was called with invalid argument "--require=foo,invalid"
```

After:

```
$ myapp console --require=foo
["foo"]

$ myapp console --require=foo,bar
["foo", "bar"]

$ myapp console --require=foo,invalid
ERROR: invalid argument "["foo", "invalid"]" for "require"; accepted values: foo, bar, baz
```

To fix this, provide OptionParser the `Array` conversion only for array options, and check for valid values in `Parser` instead, raising `ValueError` when needed. For non-array options, continue to provide `values` to OptionParser, so its abbreviation matching is unaffected.

`Parser` checks for valid values using `Option#valid_value?`, which had a separate bug: its array handling used `(value - available_values).empty?`, which compares members using `eql?`, so e.g. `"1"` would never match `1`. So an option declaring `values: [1, 2, 3]` would reject everything given on the command line. Fix this via casting values to strings first.