### PR TITLE
Cast array arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,16 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 ### Fixed
 
 - Optional arguments were incorrectly displayed at the end of usage message (@gustavothecoder in #145)
+- Arguments combining `type: :array` with `cast:` are now cast. Previously the cast was silently ignored for array arguments, and applied to array options only. (@timriley in #162)
+
+  ```ruby
+  argument :lines, type: :array, cast: ->(v) { Integer(v) }
+  ```
+
+  ```
+  cmd 1 2  # was ["1", "2"], now [1, 2]
+  ```
+- An `argument` with `type: :array` is now always given to the command as an array. When the command declared more arguments than were given, it previously received no value at all. (@timriley in #162)
 
 ### Security
 

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -50,7 +50,9 @@ module Dry
         unused_arguments = arguments.drop(command.required_arguments.length)
 
         unless all_required_params_satisfied
-          parsed_required_params_values = parsed_required_params.values.compact
+          # Drop nils as well as empty arrays; an array argument that consumed nothing was not
+          # given, so it shouldn't be listed among the arguments that were.
+          parsed_required_params_values = parsed_required_params.values.compact.reject { |v| v.is_a?(Array) && v.empty? }
 
           usage = "\nUsage: \"#{prog_name} #{command.required_arguments.map(&:description_name).join(" ")}"
 
@@ -72,27 +74,30 @@ module Dry
       end
       # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity, Layout/LineLength
 
+      # rubocop:disable Metrics/PerceivedComplexity
       def self.match_arguments(command_arguments, arguments, default_values)
         result = {}
 
-        arg = nil
         command_arguments.each_with_index do |cmd_arg, index|
-          if cmd_arg.array?
-            arg = arguments[index..] || default_values[cmd_arg.name]
-            raise ValueError.new(value: arg, argument: cmd_arg) unless cmd_arg.valid_value?(arg)
+          value =
+            if cmd_arg.array?
+              # An array argument consumes all the remaining arguments, so it's always the last.
+              # The slice is nil when the command declares more arguments than were given.
+              arguments[index..] || default_values[cmd_arg.name] || []
+            else
+              arguments.at(index) || default_values[cmd_arg.name]
+            end
 
-            result[cmd_arg.name] = arg
-            break
-          else
-            value = arguments.at(index) || default_values[cmd_arg.name]
-            raise ValueError.new(value: value, argument: cmd_arg) unless cmd_arg.valid_value?(value)
+          raise ValueError.new(value: value, argument: cmd_arg) unless cmd_arg.valid_value?(value)
 
-            result[cmd_arg.name] = cmd_arg.cast(value)
-          end
+          result[cmd_arg.name] = cmd_arg.cast(value)
+
+          break if cmd_arg.array?
         end
 
         result
       end
+      # rubocop:enable Metrics/PerceivedComplexity
 
       # @since 0.1.0
       # @api private

--- a/spec/integration/casting_spec.rb
+++ b/spec/integration/casting_spec.rb
@@ -53,5 +53,19 @@ RSpec.describe "arguments casting" do
         {"lines" => 10, "sudo_mode" => false, "type" => "system", "flags" => ["oof", "zab", "hazooh"]}
       )
     end
+
+    it "with :array type casts every element of an argument" do
+      output, _ = Open3.capture3("with_casting tags foo baz")
+
+      expect(JSON.parse(output.chomp)).to eq(
+        {"tags" => ["FOO", "BAZ"], "args" => ["foo", "baz"]}
+      )
+    end
+
+    it "with :array type leaves an omitted argument uncast" do
+      output, _ = Open3.capture3("with_casting tags")
+
+      expect(JSON.parse(output.chomp)).to eq({"tags" => []})
+    end
   end
 end

--- a/spec/support/fixtures/with_casting
+++ b/spec/support/fixtures/with_casting
@@ -26,7 +26,18 @@ module WithDryTypes
     end
   end
 
+  class Tags < Dry::CLI::Command
+    desc "Display tags"
+
+    argument :tags, desc: "Tags to display", type: :array, cast: ->(t) { t.upcase }
+
+    def call(**options)
+      puts JSON.dump(options)
+    end
+  end
+
   register "info", Info
+  register "tags", Tags
 end
 
 Dry.CLI(WithDryTypes).call


### PR DESCRIPTION
`Parser.match_arguments` had separate branches for array and non-array arguments, and only the non-array branch called `Option#cast`.

This meant that an `argument` with both `type: :array` and `cast:` would ignore the cast and return raw strings. The same declaration on an `option` would cast correctly.

To fix this, cast arguments of every type.

For example:

```ruby
argument :lines, type: :array, cast: ->(v) { Integer(v) }
```

And then running a command that outputs the value of `lines`: 

```
cmd 1 2 # was ["1", "2"], now [1, 2]
```

While here, improve the handling around missing values for array arguments. These arguments are always "trailing", so they may end up with no values supplied. Previously this resulted in a `nil` value, whereas now it is an empty array, which also avoids a crash when an `argument` declared `values:`.

For the purposes of error messaging around missing required array arguments, preserve the existing “was called with no arguments” language.