### PR TITLE
List accepted values consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
   ```
 
 - Improved error messages to be more precise and helpful (@katafrakt in #158)
+- Accepted values are now listed the same way in help output as in error messages, separated by commas rather than slashes. (@timriley in #163)
 
 ### Deprecated
 

--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -260,7 +260,7 @@ module Dry
       #   # # ...
       #   #
       #   # Options:
-      #   #   --engine=VALUE                  # Force a console engine: (irb/pry/ripl)
+      #   #   --engine=VALUE                  # Force a console engine: (irb, pry, ripl)
       #   #   --help, -h                      # Print this help
       #
       # @example Boolean

--- a/lib/dry/cli/errors.rb
+++ b/lib/dry/cli/errors.rb
@@ -23,8 +23,8 @@ module Dry
         if @value.nil? && @argument
           "ERROR: \"#{@argument.name}\" is required"
         elsif @argument
-          accepted = @argument.values
-          "ERROR: invalid argument \"#{@value}\" for \"#{@argument.name}\"; accepted values: #{accepted.join(', ')}"
+          "ERROR: invalid argument \"#{@value}\" for \"#{@argument.name}\"; " \
+            "accepted values: #{@argument.values_description}"
         else
           "ERROR: invalid argument \"#{@value}\""
         end

--- a/lib/dry/cli/option.rb
+++ b/lib/dry/cli/option.rb
@@ -41,7 +41,7 @@ module Dry
       # @api private
       def desc
         desc = options[:desc]
-        values ? "#{desc}: (#{values.join("/")})" : desc
+        values ? "#{desc}: (#{values_description})" : desc
       end
 
       # @since 0.1.0
@@ -60,6 +60,13 @@ module Dry
       # @api private
       def cast_callable
         options[:cast]
+      end
+
+      # Returns a human-readable list of this option's accepted `values`, e.g. "irb, pry, ripl".
+      #
+      # @api private
+      def values_description
+        values&.join(", ")
       end
 
       # @since 0.1.0

--- a/spec/unit/dry/cli/command_spec.rb
+++ b/spec/unit/dry/cli/command_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Command" do
       expect(opts.size).to eq(1)
       op = opts.first
       expect(op.name).to eq(:engine)
-      expect(op.desc).to eq("2: (test1/test2/test3)")
+      expect(op.desc).to eq("2: (test1, test2, test3)")
     end
   end
 


### PR DESCRIPTION
Help output would separate an option's accepted values with slashes, e.g. "(irb/pry/ripl)", while error messages separated these with commas.

Add a new `Option#values_description` method and use this to render the values from both places, using commas for the formatting.