### PR TITLE
Free up `#initialize` for command subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,21 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 - Commands and callbacks are now passed only the params their `#call` actually declares, so they no longer need a `**` catch-all to tolerate params contributed by other gems. (@afomera in #165)
 
     Params are passed through in full when `#call` can take them as a whole: when it declares a keyword splat or a positional. Otherwise they're matched against the keywords it declares.
+- `Dry::CLI::Command.new` now takes three keyword arguments: `stdout:`, `stdin:` and `stderr:`. These can be used to inject I/O streams, which is useful for testing. (@aaronmallen in #151, @timriley in #167)
 
-- [POTENTIALLY BREAKING] `Dry::CLI::Command`'s constructor now takes three keyword arguments: `stdout:`, `stdin:`, and `:stderr`. They can be used to inject I/O stream, which is useful for testing.
+    These arguments are taken by `.new` and set on the command instance before `#initialize` runs, so `#initialize` in a subclass only needs to worry about its own arguments, with no call to `super` required:
+
+    ```ruby
+    class Generate < Dry::CLI::Command
+      def initialize(generator: Generator.new)
+        @generator = generator
+      end
+    end
+
+    Generate.new(stdout: io, generator: generator)
+    ```
+
+    A command registered as an instance will have its streams replaced after it is built, so avoid building on top of the streams from inside `#initialize`. Instead, build from a stream lazily, only when you use it. See `Dry::CLI::Command` for details.
 - The `example` DSL now takes the example and its description as separate arguments, called once per example. Previously, examples were passed as a single array of strings with the description embedded after a `#`. (@aaronmallen and @timriley in #152)
 
   ```ruby

--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -9,6 +9,29 @@ module Dry
   class CLI
     # Base class for commands
     #
+    # ## Streams
+    #
+    # A command should write to the streams it is given, available as {#stdout}, {#stderr} and
+    # {#stdin}. These are set before `#initialize` runs, so you can access them in your
+    # `#initialize` as required.
+    #
+    # A command registered as an instance (instead of a class) is built before the CLI knows where
+    # its output should go, so at that point {#stdout} and {#stderr} fall back to Ruby's standard
+    # `$stdout` and `$stderr`. The CLI's real streams arrive later, when the command is called, so
+    # you should build on top of streams only when you use them:
+    #
+    # ```
+    # # Wrong: built at initialization; captures the fallback stream
+    # def initialize
+    #   @logger = Logger.new(stdout)
+    # end
+    #
+    # # Right: built on first use; captures the stream the CLI is using
+    # def logger
+    #   @logger ||= Logger.new(stdout)
+    # end
+    # ```
+    #
     # @since 0.1.0
     class Command
       include StyleMixin
@@ -439,14 +462,26 @@ module Dry
         superclass_variable_dup(:@options)
       end
 
+      # Returns a new command.
+      #
+      # The command is configured to write to the given streams, which are taken here and set on the
+      # command before `#initialize` runs. This allows a subclass to declare its own `#initialize`
+      # concerned with only its own arguments, and still use {#stdout}, {#stderr} and {#stdin}
+      # inside `#initialize` as needed. All other arguments are passed along untouched.
+      #
+      # @param stderr [IO, Dry::CLI::Stream, nil] the stream for error output
+      # @param stdin [IO, Dry::CLI::Stream, nil] the stream for input
+      # @param stdout [IO, Dry::CLI::Stream, nil] the stream for output
+      #
+      # @return [Dry::CLI::Command]
+      #
       # @since x.y.z
       # @api public
-      def initialize(stderr: nil, stdin: nil, stdout: nil)
-        @stderr = stderr
-        @stdin  = stdin
-        @stdout = stdout
-        @stderr_stream = nil
-        @stdout_stream = nil
+      def self.new(*args, stderr: nil, stdin: nil, stdout: nil, **kwargs, &block)
+        allocate.tap { |command|
+          command.send(:set_streams, stderr:, stdin:, stdout:)
+          command.send(:initialize, *args, **kwargs, &block)
+        }
       end
 
       # Returns a copy of this command, configured to write to the given streams.

--- a/spec/unit/dry/cli/command_spec.rb
+++ b/spec/unit/dry/cli/command_spec.rb
@@ -45,6 +45,109 @@ RSpec.describe "Command" do
     end
   end
 
+  # Commands are given their streams before `#initialize` runs, so they have no `super` to call
+  # rubocop:disable Lint/MissingSuper
+  describe "construction" do
+    let(:command_class) do
+      Class.new(Dry::CLI::Command) do
+        attr_reader :greeting
+
+        def initialize(greeting: "Hello")
+          @greeting = greeting
+        end
+
+        def call(**) = puts(greeting)
+      end
+    end
+
+    it "gives a subclass its streams without them reaching #initialize" do
+      out = StringIO.new
+
+      command = command_class.new(stdout: out, greeting: "Howdy")
+
+      expect(command.greeting).to eq "Howdy"
+      command.call
+      expect(out.string).to eq "Howdy\n"
+    end
+
+    it "makes the streams available inside #initialize" do
+      out = StringIO.new
+
+      Class.new(Dry::CLI::Command) {
+        def initialize
+          puts "Initialized"
+        end
+      }.new(stdout: out)
+
+      expect(out.string).to eq "Initialized\n"
+    end
+
+    it "passes along everything else the subclass asks for" do
+      command = Class.new(Dry::CLI::Command) do
+        attr_reader :args, :block
+
+        def initialize(*args, **kwargs, &block)
+          @args = [args, kwargs]
+          @block = block
+        end
+      end
+
+      instance = command.new(1, 2, stdout: StringIO.new, dep: "dep") { :called }
+
+      expect(instance.args).to eq [[1, 2], {dep: "dep"}]
+      expect(instance.block.call).to be :called
+    end
+
+    it "rejects keywords the command does not accept" do
+      command = Class.new(Dry::CLI::Command)
+
+      expect { command.new(stdou: StringIO.new) }.to raise_error ArgumentError
+    end
+
+    it "allows a subclass to catch and forward our stream keywords itself" do
+      out = StringIO.new
+      command = Class.new(Dry::CLI::Command) do
+        def initialize(greeting: "Hello", **opts)
+          super(**opts)
+          @greeting = greeting
+        end
+
+        def call(**) = puts(@greeting)
+      end
+
+      command.new(stdout: out, greeting: "Howdy").call
+
+      expect(out.string).to eq "Howdy\n"
+    end
+  end
+
+  describe "#with_streams" do
+    let(:command_class) do
+      Class.new(Dry::CLI::Command) do
+        def initialize(greeting: "Hello")
+          @greeting = greeting
+        end
+
+        def call(**) = puts(@greeting)
+      end
+    end
+
+    it "returns a copy writing to the given streams, leaving the original alone" do
+      original_out = StringIO.new
+      copy_out = StringIO.new
+      command = command_class.new(stdout: original_out, greeting: "Howdy")
+
+      copy = command.with_streams(stderr: StringIO.new, stdin: StringIO.new, stdout: copy_out)
+
+      command.call
+      copy.call
+      copy.call
+      expect(copy_out.string).to eq "Howdy\nHowdy\n"
+      expect(original_out.string).to eq "Howdy\n"
+    end
+  end
+  # rubocop:enable Lint/MissingSuper
+
   describe "writing output" do
     let(:command) do
       Class.new(Dry::CLI::Command) do


### PR DESCRIPTION
Free up `#initialize` in command subclasses so they can use it for their own purposes only.

`stdin:`, `stdout:`, and `stderr:` are still injectable dependencies, but these are handled by `.new`, which sets them as instance variables directly, before forwarding all other args onto `#initialize`.

Aside from reducing boilerplate for users in their command subclasses, this also decreases the risk of bugs. Without this, every command subclass that adds its own `#initialize` needs to remember to accept `**args` and then call `super(**args)`, otherwise the streams would never be set.

I thought of this change as part of updating hanami-cli to use the new streams provided as part of dry-cli v2. Now that I've made this change here, my next step will be to show what the updated hanami-cli commands look like. Stand by for that, but in the meantime, I'm still interested in feedback on this change in isolation :)